### PR TITLE
Machine annotation services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.9.0",
         "react-scripts": "5.0.1",
+        "react-tabs": "^6.0.1",
         "sass": "^1.59.2",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -5807,6 +5808,14 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/co": {
@@ -14728,6 +14737,18 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-tabs": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/react-tabs/-/react-tabs-6.0.1.tgz",
+      "integrity": "sha512-XE5D/iCcwUsr06wf6fWrjA/HbUaj3G2+6NMVJygZuKALHkWYp+D3ZPcG2VctuaOHHzMU48eSOuxwBALBnuXldA==",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "prop-types": "^15.5.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.9.0",
     "react-scripts": "5.0.1",
+    "react-tabs": "^6.0.1",
     "sass": "^1.59.2",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/public/index.html
+++ b/public/index.html
@@ -11,10 +11,10 @@
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
    
-    <title> Orchestration Service </title>
+    <title> Orchestration Services </title>
   </head>
   <body>
-    <noscript> You need to enable JavaScript to use the Orchestration Service. </noscript>
+    <noscript> You need to enable JavaScript to use the Orchestration Services. </noscript>
     
     <div id="root"></div>
   </body>

--- a/public/silent-check-sso.html
+++ b/public/silent-check-sso.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html lang="en"><head><title>Siltent-Check-SSO</title></head><body><script>parent.postMessage(location.href, location.origin)</script></body></html>

--- a/src/App.css
+++ b/src/App.css
@@ -30,6 +30,7 @@
 
 html {
   height: 100%;
+  background-color: #F9FAFC;
 }
 
 body {
@@ -49,6 +50,21 @@ body {
 .content {
   height: 90%;
 }
+
+/* Backgrounds */
+.bgc-primary {
+  background-color: var(--primary);
+}
+
+.bgc-secondary {
+  background-color: var(--secondary);
+}
+
+.bgc-accent {
+  backdrop-filter: var(--accent);
+}
+
+.bgc-
 
 /* Font Weight */
 .fw-lightBold {

--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,9 @@
 /* Root variables */
 
 :root {
+  --primary: #4d59a2;
+  --secondary: #51a993;
+  --accent: #28bacb;
   --main-color: #0C86C6;
   --main-color-light: #d6e0f5;
   --main-color-dark: #1c497d;
@@ -23,7 +26,7 @@
 }
 
 
-/* General Styling */
+/* Global Styling */
 
 html {
   height: 100%;
@@ -45,6 +48,35 @@ body {
 
 .content {
   height: 90%;
+}
+
+/* Font Weight */
+.fw-lightBold {
+  font-weight: 500;
+}
+
+/* Cursor */
+.c-pointer {
+  cursor: pointer;
+}
+
+
+/* Custom Component Styling */
+.primaryButton {
+  background-color: var(--primary);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  transition: 0.4s;
+  font-weight: 500;
+}
+
+.primaryButton:hover {
+  background-color: var(--accent);
+}
+
+.primaryButton.cancel {
+  background-color: #CBCCD4;
 }
 
 
@@ -93,4 +125,9 @@ body {
   overflow: hidden;
   padding-top: 11.2%;
   border: none;
+}
+
+.modalHeader {
+  background-color: var(--primary);
+  color: white
 }

--- a/src/App.css
+++ b/src/App.css
@@ -30,7 +30,6 @@
 
 html {
   height: 100%;
-  background-color: #F9FAFC;
 }
 
 body {
@@ -41,6 +40,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #F9FAFC;
 }
 
 #root {
@@ -49,6 +49,19 @@ body {
 
 .content {
   height: 90%;
+}
+
+/* Colors */
+.c-primary {
+  color: var(--primary);
+}
+
+.c-secondary {
+  color: var(--secondary);
+}
+
+.c-accent {
+  color: var(--accent);
 }
 
 /* Backgrounds */
@@ -84,6 +97,7 @@ body {
   border: none;
   border-radius: 999px;
   transition: 0.4s;
+  font-size: 15px;
   font-weight: 500;
 }
 
@@ -103,7 +117,8 @@ body {
   border-top: 1px solid #d9d9d9;
 }
 
-.nav-tabs .nav-item.show, .nav-tabs .nav-link.active {
+.nav-tabs .nav-item.show,
+.nav-tabs .nav-link.active {
   color: white;
   background-color: var(--main-color-dark);
   border-color: none;
@@ -118,13 +133,51 @@ body {
   border-bottom: none;
 }
 
-.nav-tabs .nav-link:hover{
+.nav-tabs .nav-link:hover {
   color: gray
 }
 
 .tab-pane {
   height: 100%;
   padding-top: 2%;
+}
+
+li.page-item.active .page-link {
+  background-color: var(--secondary);
+  border: none;
+}
+
+.dropdown {
+  padding-right: 0;
+}
+
+.dropdown-toggle {
+  background-color: #F9FAFC !important;
+  color: #333333 !important;
+  border: 1px solid #F9FAFC !important;
+}
+
+.dropdown-toggle:hover {
+  background-color: white !important;
+  border: 1px solid var(--secondary) !important;
+}
+
+
+/* AG Table Overwrite */
+.ag-root-wrapper {
+  border-radius: 8px;
+}
+
+.ag-row-hover {
+  background-color: #a1d8ca !important;
+}
+
+.ag-header {
+  background-color: var(--secondary) !important;
+}
+
+.ag-header-cell {
+  color: white;
 }
 
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,22 +4,35 @@ import {
   Routes,
   Route
 } from "react-router-dom";
+import KeycloakService from "keycloak/Keycloak";
 
 /* Import Styles */
 import './App.css';
 
 /* Import Components */
 import Home from "components/home/Home";
+import Landing from "components/landing/Landing";
 
 
 const App = () => {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-      </Routes>
-    </Router>
-  );
+  /* If user is logged in, show actionable Home page, otherwise show landing page */
+  if (KeycloakService.IsLoggedIn()) {
+    return (
+      <Router>
+        <Routes>
+          <Route path="/" element={<Home />} />
+        </Routes>
+      </Router>
+    );
+  } else {
+    return (
+      <Router>
+        <Routes>
+          <Route path="/" element={<Landing />} />
+        </Routes>
+      </Router>
+    );
+  }
 }
 
 export default App;

--- a/src/api/mas/DeleteMAS.ts
+++ b/src/api/mas/DeleteMAS.ts
@@ -1,0 +1,27 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+
+const DeleteMAS = async (handle?: string, token?: string) => {
+    if (handle && token) {
+        let response;
+
+        const endPoint = `mas/${handle}`;
+
+        await axios({
+            method: "delete",
+            url: endPoint,
+            headers: {
+                'Authorization': `Bearer ${token}`
+            },
+        }).then(() => {
+            response = true;
+        }).catch((error) => {
+            console.warn(error);
+        });
+
+        return response;
+    }
+}
+
+export default DeleteMAS;

--- a/src/api/mas/GetMAS.ts
+++ b/src/api/mas/GetMAS.ts
@@ -1,0 +1,38 @@
+/* Import Dependencies */
+import axios from "axios";
+
+/* Import Model */
+import MASModel from "api/model/MASModel";
+
+/* Import Types */
+import { MAS, JSONResult, Dict } from "global/Types";
+
+
+const GetMAS = async () => {
+    let machineAnnotationServices = <MAS[]>[];
+
+    const endPoint = "/mas"
+
+    try {
+        const result = await axios({
+            method: "get",
+            url: endPoint,
+            params: {
+                pageSize: 50
+            },
+            responseType: 'json'
+        });
+
+        const data: JSONResult = result.data;
+
+        Object.values(data.data).forEach((machineAnnotationService) => {
+            machineAnnotationServices.push(MASModel(machineAnnotationService as Dict));
+        });
+    } catch (error) {
+        console.warn(error);
+    }
+
+    return machineAnnotationServices;
+}
+
+export default GetMAS;

--- a/src/api/mas/InsertMAS.ts
+++ b/src/api/mas/InsertMAS.ts
@@ -1,0 +1,39 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { MAS, JSONResult, Dict } from 'global/Types';
+
+/* Import Model */
+import MASModel from 'api/model/MASModel';
+
+
+const InsertMAS = async (MASRecord: Dict, token?: string) => {
+    if (MASRecord && token) {
+        let machineAnnoationService = <MAS>{};
+
+        const endPoint = '/mas';
+
+        await axios({
+            method: "post",
+            url: endPoint,
+            data: MASRecord,
+            responseType: 'json',
+            headers: {
+                'Content-type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+        }).then((result) => {
+            /* Set Machine Annotation Service */
+            const data: JSONResult = result.data;
+
+            machineAnnoationService = MASModel(data.data);
+        }).catch((error) => {
+            console.warn(error);
+        });
+
+        return machineAnnoationService;
+    }
+}
+
+export default InsertMAS;

--- a/src/api/mas/PatchMAS.ts
+++ b/src/api/mas/PatchMAS.ts
@@ -1,0 +1,39 @@
+/* Import Dependencies */
+import axios from 'axios';
+
+/* Import Types */
+import { MAS, JSONResult, Dict } from 'global/Types';
+
+/* Import Model */
+import MASModel from 'api/model/MASModel';
+
+
+const PatchMAS = async (MASRecord: Dict, MASId: string, token?: string) => {
+    if (MASRecord && token) {
+        let machineAnnoationService = <MAS>{};
+
+        const endPoint = `/mas/${MASId}`;
+
+        await axios({
+            method: "patch",
+            url: endPoint,
+            data: MASRecord,
+            responseType: 'json',
+            headers: {
+                'Content-type': 'application/json',
+                'Authorization': `Bearer ${token}`
+            },
+        }).then((result) => {
+            /* Set Machine annotation service */
+            const data: JSONResult = result.data;
+
+            machineAnnoationService = MASModel(data.data);
+        }).catch((error) => {
+            console.warn(error);
+        });
+
+        return machineAnnoationService;
+    }
+}
+
+export default PatchMAS;

--- a/src/api/model/MASModel.ts
+++ b/src/api/model/MASModel.ts
@@ -1,0 +1,27 @@
+/* Import Types */
+import { MAS as MASType, Dict } from "global/Types"
+
+
+/* Source System Model for API calls */
+const MASModel = (result: Dict) => {
+    const MAS: MASType = {
+        id: result.id,
+        name: result.attributes.name,
+        containerImage: result.attributes.containerImage,
+        containerTag: result.attributes.containerTag,
+        targetDigitalObjectFilters: result.attributes.targetDigitalObjectFilters,
+        serviceDescription: result.attributes.serviceDescription,
+        serviceState: result.attributes.serviceState,
+        sourceCodeRepository: result.attributes.sourceCodeRepository,
+        serviceAvailability: result.attributes.serviceAvailability,
+        codeMaintainer: result.attributes.codeMaintainer,
+        codeLicense: result.attributes.codeLicense,
+        dependencies: result.attributes.dependencies,
+        supportContact: result.attributes.supportContact,
+        slaDocumentation: result.attributes.slaDocumentation
+    }
+
+    return MAS;
+}
+
+export default MASModel;

--- a/src/app/Store.ts
+++ b/src/app/Store.ts
@@ -4,6 +4,7 @@ import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 /* Import Redux Slices */
 import SourceSystemReducer from 'redux/sourceSystem/SourceSystemSlice';
 import MappingReducer from 'redux/mapping/MappingSlice';
+import MASReducer from 'redux/MAS/MASSlice';
 import EditReducer from 'redux/edit/EditSlice';
 
 
@@ -11,6 +12,7 @@ export const store = configureStore({
   reducer: {
     sourceSystem: SourceSystemReducer,
     mapping: MappingReducer,
+    machineAnnotationServices: MASReducer,
     edit: EditReducer
   },
 });

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
                     <img src={DiSSCoLogo} className="h-100" />
                 </Col>
                 <Col className="col-md-auto d-flex align-items-center">
-                    <h1 className={styles.title}>Orchestration Service</h1>
+                    <h1 className={`${styles.title} c-primary`}>Orchestration Services</h1>
                 </Col>
                 <Col className="d-flex justify-content-end align-items-center">
                     <Profile />

--- a/src/components/Header/header.module.scss
+++ b/src/components/Header/header.module.scss
@@ -6,5 +6,4 @@
 
 .title {
     font-size: 28px;
-    color: var(--main-color-dark);
 }

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -115,7 +115,7 @@ const Home = () => {
         const copyMachineAnnotationServices = [...machineAnnotationServices];
         const MASIndex = machineAnnotationServices.findIndex(MASRecord => MASRecord.id === MASId);
 
-        /* If Source System object is present, update main array, else remove */
+        /* If Machine Annotation Service object is present, update main array, else remove */
         if (MAS && MASIndex > 0) {
             copyMachineAnnotationServices[MASIndex] = MAS;
         } else if (MAS) {

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -6,9 +6,10 @@ import { Container, Row, Col, Tabs, Tab } from 'react-bootstrap';
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
 import { getSourceSystems, setSourceSystems } from 'redux/sourceSystem/SourceSystemSlice';
 import { getMappings, setMappings } from 'redux/mapping/MappingSlice';
+import { getMachineAnnotationServices, setMachineAnnotationServices } from 'redux/MAS/MASSlice';
 
 /* Import Types */
-import { SourceSystem, Mapping } from 'global/Types';
+import { SourceSystem, Mapping, MAS } from 'global/Types';
 
 /* Import Styles */
 import styles from 'components/home/home.module.scss';
@@ -17,11 +18,13 @@ import styles from 'components/home/home.module.scss';
 import Header from 'components/Header/Header';
 import SourceSystemsOverview from './components/overview/SourceSystemsOverview';
 import MappingsOverview from './components/overview/MappingsOverview';
+import MASOverview from './components/overview/MASOverview';
 import FormModal from './components/forms/FormModal';
 
 /* Import API */
 import GetSourceSystems from 'api/sourceSystem/GetSourceSystems';
 import GetMappings from 'api/mapping/GetMappings';
+import GetMAS from 'api/mas/GetMAS';
 
 
 const Home = () => {
@@ -31,15 +34,26 @@ const Home = () => {
     /* Base variables */
     const sourceSystems = useAppSelector(getSourceSystems);
     const mappings = useAppSelector(getMappings);
+    const machineAnnotationServices = useAppSelector(getMachineAnnotationServices);
 
-    /* OnLoad: Get Source Systems and Mappings */
+    /* OnLoad: Get Source Systems, Mappings and Machine annotation services */
     useEffect(() => {
         GetSourceSystems().then((sourceSystems) => {
             dispatch(setSourceSystems(sourceSystems));
+        }).catch(error => {
+            console.warn(error);
         });
 
         GetMappings().then((mappings) => {
             dispatch(setMappings(mappings));
+        }).catch(error => {
+            console.warn(error);
+        });
+
+        GetMAS().then((machineAnnotationServices) => {
+            dispatch(setMachineAnnotationServices(machineAnnotationServices));
+        }).catch(error => {
+            console.warn(error);
         });
     }, []);
 
@@ -111,6 +125,12 @@ const Home = () => {
                                 <MappingsOverview ToggleModal={() => setModalToggle(true)}
                                     UpdateMappings={(mappingId: string, mapping?: Mapping) =>
                                         UpdateMappings(mappingId, mapping)}
+                                />
+                            </Tab>
+                            <Tab eventKey="MAS" title="Machine annotation services">
+                                <MASOverview ToggleModal={() => setModalToggle(true)}
+                                    UpdateMachineAnnotationServices={(MASId: string, MAS?: MAS) =>
+                                        console.log('test')}// UpdateMappings(mappingId, mapping)}
                                 />
                             </Tab>
                         </Tabs>

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,6 +1,8 @@
 /* Import Dependencies */
 import { useEffect, useState } from 'react';
-import { Container, Row, Col, Tabs, Tab } from 'react-bootstrap';
+import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
+import classNames from 'classnames';
+import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
@@ -64,6 +66,16 @@ const Home = () => {
     /* Function for tracking the chosen tab */
     const [chosenTab, setChosenTab] = useState('Source System');
 
+    const SetChosenTab = (tabNumber: number) => {
+        if (tabNumber === 0) {
+            setChosenTab('Source System');
+        } else if (tabNumber === 1) {
+            setChosenTab('Mapping');
+        } else if (tabNumber === 2) {
+            setChosenTab('MAS')
+        }
+    }
+
     /* Function for updating the Source Systems state */
     const UpdateSourceSystems = (sourceSystemId: string, sourceSystem?: SourceSystem) => {
         const copySourceSystems = [...sourceSystems];
@@ -115,6 +127,21 @@ const Home = () => {
         dispatch(setMachineAnnotationServices(copyMachineAnnotationServices));
     }
 
+    /* Class Names for Tabs */
+    const classTabsList = classNames({
+        [`${styles.tabsList}`]: true
+    });
+
+    const classTab = classNames({
+        'react-tabs__tab': true,
+        [`${styles.tab}`]: true
+    });
+
+    const classTabPanel = classNames({
+        'react-tabs__tab-panel': true,
+        [`${styles.tabPanel}`]: true
+    });
+
     return (
         <div className="h-100">
             <Header />
@@ -123,34 +150,44 @@ const Home = () => {
                 <Row className="h-100">
                     <Col className="h-100">
                         <div className="position-relative">
-                            <button className={`${styles.addButton} position-absolute px-3 py-1 end-0`}
+                            <button className={`${styles.addButton} primaryButton position-absolute px-3 py-1 end-0`}
                                 onClick={() => setModalToggle(true)}
                             >
                                 Add {chosenTab}
                             </button>
                         </div>
 
-                        <Tabs defaultActiveKey="Source System"
-                            onSelect={(tab) => setChosenTab(tab as string)}
-                        >
-                            <Tab eventKey="Source System" title="Source Systems">
+                        {/* Tabs with different orchestration services */}
+                        <Tabs className="h-100" onSelect={(tab) => SetChosenTab(tab)}>
+                            <TabList className={classTabsList}>
+                                <Tab className={classTab} selectedClassName={styles.active}> Source Systems </Tab>
+                                <Tab className={classTab} selectedClassName={styles.active}> Mappings </Tab>
+                                <Tab className={classTab} selectedClassName={styles.active}> Machine Annotation Services </Tab>
+                            </TabList>
+
+                            {/* Source Systems */}
+                            <TabPanel className={classTabPanel}>
                                 <SourceSystemsOverview ToggleModal={() => setModalToggle(true)}
                                     UpdateSourceSystems={(sourceSystemId: string, sourceSystem?: SourceSystem) =>
                                         UpdateSourceSystems(sourceSystemId, sourceSystem)}
                                 />
-                            </Tab>
-                            <Tab eventKey="Mapping" title="Mappings">
+                            </TabPanel>
+
+                            {/* Mappings */}
+                            <TabPanel className={classTabPanel}>
                                 <MappingsOverview ToggleModal={() => setModalToggle(true)}
                                     UpdateMappings={(mappingId: string, mapping?: Mapping) =>
                                         UpdateMappings(mappingId, mapping)}
                                 />
-                            </Tab>
-                            <Tab eventKey="MAS" title="Machine annotation services">
+                            </TabPanel>
+
+                            {/* Machine Annotation Services */}
+                            <TabPanel className={classTabPanel}>
                                 <MASOverview ToggleModal={() => setModalToggle(true)}
                                     UpdateMachineAnnotationServices={(MASId: string, MAS?: MAS) =>
                                         UpdateMachineAnnotationServices(MASId, MAS)}
                                 />
-                            </Tab>
+                            </TabPanel>
                         </Tabs>
                     </Col>
                 </Row>

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -19,7 +19,8 @@ import Header from 'components/Header/Header';
 import SourceSystemsOverview from './components/overview/SourceSystemsOverview';
 import MappingsOverview from './components/overview/MappingsOverview';
 import MASOverview from './components/overview/MASOverview';
-import FormModal from './components/forms/FormModal';
+import SourceSystemMappingModal from './components/modals/SourceSystemMappingModal';
+import MASModal from './components/modals/MASModal';
 
 /* Import API */
 import GetSourceSystems from 'api/sourceSystem/GetSourceSystems';
@@ -97,6 +98,23 @@ const Home = () => {
         dispatch(setMappings(copyMappings));
     }
 
+    /* Function for updating the Machine Annotation Services state */
+    const UpdateMachineAnnotationServices = (MASId: string, MAS?: MAS) => {
+        const copyMachineAnnotationServices = [...machineAnnotationServices];
+        const MASIndex = machineAnnotationServices.findIndex(MASRecord => MASRecord.id === MASId);
+
+        /* If Source System object is present, update main array, else remove */
+        if (MAS && MASIndex > 0) {
+            copyMachineAnnotationServices[MASIndex] = MAS;
+        } else if (MAS) {
+            copyMachineAnnotationServices.push(MAS);
+        } else {
+            copyMachineAnnotationServices.splice(MASIndex, 1);
+        }
+
+        dispatch(setMachineAnnotationServices(copyMachineAnnotationServices));
+    }
+
     return (
         <div className="h-100">
             <Header />
@@ -130,14 +148,15 @@ const Home = () => {
                             <Tab eventKey="MAS" title="Machine annotation services">
                                 <MASOverview ToggleModal={() => setModalToggle(true)}
                                     UpdateMachineAnnotationServices={(MASId: string, MAS?: MAS) =>
-                                        console.log('test')}// UpdateMappings(mappingId, mapping)}
+                                        UpdateMachineAnnotationServices(MASId, MAS)}
                                 />
                             </Tab>
                         </Tabs>
                     </Col>
                 </Row>
 
-                <FormModal modalToggle={modalToggle}
+                {/* Form Modal for adding or editing Source Systems or Mappings */}
+                <SourceSystemMappingModal modalToggle={(modalToggle && (chosenTab === 'Source System' || chosenTab === 'Mapping'))}
                     chosenTab={chosenTab}
 
                     ToggleModal={() => setModalToggle(!modalToggle)}
@@ -145,6 +164,12 @@ const Home = () => {
                         UpdateSourceSystems(sourceSystemId, sourceSystem)}
                     UpdateMappings={(mappingId: string, mapping?: Mapping) =>
                         UpdateMappings(mappingId, mapping)}
+                />
+
+                {/* Form Modal for adding or editing Machine annotation services */}
+                <MASModal modalToggle={(modalToggle && chosenTab === 'MAS')}
+                    ToggleModal={() => setModalToggle(!modalToggle)}
+                    UpdateMachineAnnotationServices={(MASId: string, MAS: MAS) => UpdateMachineAnnotationServices(MASId, MAS)}
                 />
             </Container>
         </div>

--- a/src/components/home/components/forms/AddMappingForm.tsx
+++ b/src/components/home/components/forms/AddMappingForm.tsx
@@ -25,7 +25,7 @@ interface Props {
 
 const AddMappingForm = (props: Props) => {
     const { formValues, baseStandard } = props;
-    
+
     /* Base variables */
     const originalHarmonisedAttributes: Dict = cloneDeep(HarmonisedAttributes);
     const harmonisedAttributes: Dict = cloneDeep(HarmonisedAttributes);
@@ -47,29 +47,31 @@ const AddMappingForm = (props: Props) => {
     return (
         <Row className="h-100">
             <Col className="h-100">
-                <Row>
-                    <Col>
-                        <h6> Construct Mapping </h6>
-                    </Col>
-                </Row>
+                <div className="h-100 d-flex flex-column">
+                    <Row>
+                        <Col>
+                            <h6> Construct Mapping </h6>
+                        </Col>
+                    </Row>
 
-                <Row style={{ height: '90%' }}>
-                    <Col className="h-100">
-                        <MappingFields mappingType={'Defaults'}
-                            formValues={formValues}
-                            harmonisedAttributes={harmonisedAttributes}
-                            originalHarmonisedAttributes={originalHarmonisedAttributes}
-                            classCoverDiv={classCoverDiv}
-                        />
-                            
-                        <MappingFields mappingType={'FieldMapping'}
-                            formValues={formValues}
-                            harmonisedAttributes={harmonisedAttributes}
-                            originalHarmonisedAttributes={originalHarmonisedAttributes}
-                            classCoverDiv={classCoverDiv}
-                        />
-                    </Col>
-                </Row>
+                    <Row className="flex-grow-1">
+                        <Col className="h-100">
+                            <MappingFields mappingType={'Defaults'}
+                                formValues={formValues}
+                                harmonisedAttributes={harmonisedAttributes}
+                                originalHarmonisedAttributes={originalHarmonisedAttributes}
+                                classCoverDiv={classCoverDiv}
+                            />
+
+                            <MappingFields mappingType={'FieldMapping'}
+                                formValues={formValues}
+                                harmonisedAttributes={harmonisedAttributes}
+                                originalHarmonisedAttributes={originalHarmonisedAttributes}
+                                classCoverDiv={classCoverDiv}
+                            />
+                        </Col>
+                    </Row>
+                </div>
             </Col>
         </Row>
     );

--- a/src/components/home/components/forms/MappingFields.tsx
+++ b/src/components/home/components/forms/MappingFields.tsx
@@ -27,7 +27,7 @@ const MappingFields = (props: Props) => {
     const { mappingType, formValues, harmonisedAttributes, originalHarmonisedAttributes, classCoverDiv } = props;
 
     return (
-        <Row className="mt-3 h-50">
+        <Row className="h-50 py-2">
             <Col className="h-100">
                 <div className={`${styles.mappingConstructBlock} px-3 py-3 h-100 position-relative`}>
                     <div className={`${classCoverDiv} position-absolute h-100 w-100 top-0 start-0

--- a/src/components/home/components/modals/MASModal.tsx
+++ b/src/components/home/components/modals/MASModal.tsx
@@ -1,0 +1,392 @@
+/* Import Dependencies */
+import { Formik, Form, Field, FieldArray } from 'formik';
+import KeycloakService from 'keycloak/Keycloak';
+import { Row, Col, Modal } from 'react-bootstrap';
+
+/* Import Store */
+import { useAppSelector } from 'app/Hooks';
+import { getEditTarget } from 'redux/edit/EditSlice';
+
+/* Import Types */
+import { Dict } from 'global/Types';
+
+/* Import Sources */
+import HarmonisedAttributes from 'sources/hamonisedAttributes.json';
+
+/* Import Styles */
+import styles from 'components/home/home.module.scss';
+
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+
+/* Import API */
+import InsertMAS from 'api/mas/InsertMAS';
+import PatchMAS from 'api/mas/PatchMAS';
+
+
+/* Props Typing */
+interface Props {
+    modalToggle: boolean,
+    ToggleModal: Function,
+    UpdateMachineAnnotationServices: Function
+};
+
+
+const MASModal = (props: Props) => {
+    const { modalToggle, ToggleModal, UpdateMachineAnnotationServices } = props;
+
+    /* Base variables */
+    const editTarget = useAppSelector(getEditTarget);
+
+    const harmonisedAttributes = { ...HarmonisedAttributes };
+
+    const initialValues = {
+        name: editTarget.MAS ? editTarget.MAS.name : '',
+        containerImage: editTarget.MAS?.containerImage ? editTarget.MAS.containerImage : '',
+        containerTag: editTarget.MAS?.containerTag ? editTarget.MAS.containerTag : '',
+        targetDigitalObjectFilters: editTarget.MAS?.targetDigitalObjectFilters ? editTarget.MAS.targetDigitalObjectFilters : {},
+        targetDigitalObjectFiltersOptions: "",
+        serviceDescription: editTarget.MAS?.serviceDescription ? editTarget.MAS.serviceDescription : '',
+        serviceState: editTarget.MAS?.serviceState ? editTarget.MAS.serviceState : '',
+        sourceCodeRepository: editTarget.MAS?.sourceCodeRepository ? editTarget.MAS.sourceCodeRepository : '',
+        serviceAvailability: editTarget.MAS?.serviceAvailability ? editTarget.MAS.serviceAvailability : '',
+        codeMaintainer: editTarget.MAS?.codeMaintainer ? editTarget.MAS.codeMaintainer : '',
+        codeLicense: editTarget.MAS?.codeLicense ? editTarget.MAS.codeLicense : '',
+        dependencies: editTarget.MAS?.dependencies ? editTarget.MAS.dependencies : [],
+        supportContact: editTarget.MAS?.supportContact ? editTarget.MAS.supportContact : '',
+        slaDocumentation: editTarget.MAS?.slaDocumentation ? editTarget.MAS.slaDocumentation : '',
+    };
+
+    /* Function for submitting the form */
+    const SubmitForm = async (form: Dict) => {
+        const MASRecord = {
+            data: {
+                type: "machineAnnotationService",
+                attributes: {
+                    name: form.name,
+                    containerImage: form.containerImage,
+                    containerTag: form.containerTag,
+                    targetDigitalObjectFilters: form.targetDigitalObjectFilters,
+                    serviceDescription: form.serviceDescription,
+                    serviceState: form.serviceState,
+                    sourceCodeRepository: form.sourceCodeRepository,
+                    serviceAvailability: form.serviceAvailability,
+                    codeMaintainer: form.codeMaintainer,
+                    codeLicense: form.codeLicense,
+                    dependencies: form.dependencies,
+                    supportContact: form.supportContact,
+                    slaDocumentation: form.slaDocumentation
+                }
+            }
+        };
+
+        /* If edit target is not empty, patch instead of insert */
+        if (editTarget.MAS) {
+            PatchMAS(MASRecord, editTarget.MAS.id, KeycloakService.GetToken()).then((MAS) => {
+                UpdateMachineAnnotationServices(MAS?.id, MAS);
+            }).catch(error => {
+                console.warn(error);
+            });
+        } else {
+            InsertMAS(MASRecord, KeycloakService.GetToken()).then((MAS) => {
+                UpdateMachineAnnotationServices(MAS?.id, MAS);
+            }).catch(error => {
+                console.warn(error);
+            });
+        }
+
+        /* Close MAS Modal */
+        ToggleModal();
+    }
+
+    return (
+        <Modal show={modalToggle} >
+            <Formik
+                initialValues={initialValues}
+                enableReinitialize={true}
+                onSubmit={async (form: any) => {
+                    await new Promise((resolve) => setTimeout(resolve, 100));
+
+                    SubmitForm(form);
+                }}
+            >
+                {({ values, setFieldValue }) => (
+                    <Form className="h-100">
+                        <Row className="h-100">
+                            <Col className="h-100">
+                                <Modal.Header className="modalHeader pb-0">
+                                    <Row className="w-100">
+                                        <Col>
+                                            <p className="fw-lightBold">
+                                                {Object.keys(editTarget).length > 0 ?
+                                                    'Edit Machine annotation service' : 'Add new Machine annotation service'
+                                                }
+                                            </p>
+                                        </Col>
+                                        <Col className="col-md-auto pe-0">
+                                            <FontAwesomeIcon icon={faX}
+                                                className="c-pointer"
+                                                onClick={() => ToggleModal()}
+                                            />
+                                        </Col>
+                                    </Row>
+                                </Modal.Header>
+                                <Modal.Body className={`${styles.formModalBody} bg-white`}>
+                                    <div className="h-100 d-flex flex-column">
+                                        {/* Form Fields */}
+                                        <Row className="mb-3 flex-grow-1 overflow-scroll">
+                                            <Col>
+                                                <Row>
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Name: </p>
+                                                        <Field name="name" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Container Image: </p>
+                                                        <Field name="containerImage" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Container Tag: </p>
+                                                        <Field name="containerTag" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <Row>
+                                                            <Col>
+                                                                <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Target Digital Object Filters: </p>
+                                                            </Col>
+                                                        </Row>
+                                                        <Row className="mb-2">
+                                                            <Col>
+                                                                {Object.keys(values.targetDigitalObjectFilters).map((objectFilter) => {
+                                                                    const objectFilterValues: [] = values.targetDigitalObjectFilters[
+                                                                        objectFilter as keyof typeof values.targetDigitalObjectFilters
+                                                                    ];
+
+                                                                    return (
+                                                                        <div key={objectFilter} className={`${styles.formFieldArrayOption} px-3 py-2`}>
+                                                                            <FieldArray name={`targetDigitalObjectFilters.${objectFilter}`}>
+                                                                                {({ push, remove }) => (
+                                                                                    <div>
+                                                                                        <Row>
+                                                                                            <Col>
+                                                                                                <p className={`${styles.formFieldArrayOptionTitle} fw-lightBold`}>
+                                                                                                    {objectFilter}
+                                                                                                </p>
+                                                                                            </Col>
+                                                                                            <Col className="col-md-auto pe-0">
+                                                                                                <button type="button" className={styles.formArrayAddButton}
+                                                                                                    onClick={() => push("")}
+                                                                                                >
+                                                                                                    Add value
+                                                                                                </button>
+                                                                                            </Col>
+                                                                                            <Col className="col-md-auto">
+                                                                                                <button type="button"
+                                                                                                    className={styles.formArrayRemoveButton}
+                                                                                                    onClick={() => {
+                                                                                                        const copyObjectFilters = { ...values.targetDigitalObjectFilters };
+
+                                                                                                        delete copyObjectFilters[
+                                                                                                            objectFilter as keyof typeof copyObjectFilters
+                                                                                                        ];
+
+                                                                                                        setFieldValue('targetDigitalObjectFilters', copyObjectFilters);
+                                                                                                    }}
+                                                                                                >
+                                                                                                    Drop filter
+                                                                                                </button>
+                                                                                            </Col>
+                                                                                        </Row>
+                                                                                        <Row>
+                                                                                            <Col>
+                                                                                                {
+                                                                                                    objectFilterValues.map((_objectFilterValue, index: number) => {
+                                                                                                        const key = `${objectFilter}_${index}`;
+
+                                                                                                        return (
+                                                                                                            <Row key={key}>
+                                                                                                                <Col md={{ span: 9 }} className="pe-0">
+                                                                                                                    <Field name={`targetDigitalObjectFilters.${objectFilter}.${index}`}
+                                                                                                                        className={`${styles.formField} w-100 mb-2`}
+                                                                                                                    />
+                                                                                                                </Col>
+                                                                                                                <Col>
+                                                                                                                    <FontAwesomeIcon icon={faX}
+                                                                                                                        onClick={() => remove(index)}
+                                                                                                                    />
+                                                                                                                </Col>
+                                                                                                            </Row>
+
+                                                                                                        );
+                                                                                                    })
+                                                                                                }
+                                                                                            </Col>
+                                                                                        </Row>
+
+                                                                                    </div>
+                                                                                )}
+                                                                            </FieldArray>
+                                                                        </div>
+                                                                    );
+                                                                })}
+                                                            </Col>
+                                                        </Row>
+                                                        <Row>
+                                                            <Col>
+                                                                <Field name="targetDigitalObjectFiltersOptions"
+                                                                    as="select"
+                                                                >
+                                                                    <option value="" disabled={true}> Select a harmonised attribute </option>
+
+                                                                    {Object.keys(harmonisedAttributes).map((filterOption) => {
+                                                                        if (!(filterOption in values.targetDigitalObjectFilters)) {
+                                                                            return <option key={filterOption} value={filterOption}> {filterOption} </option>
+                                                                        }
+                                                                    })}
+                                                                </Field>
+                                                            </Col>
+                                                            <Col>
+                                                                <button type="button" className={styles.formArrayAddButton}
+                                                                    onClick={() => {
+                                                                        if (values.targetDigitalObjectFiltersOptions !== "") {
+                                                                            /* Add filter to Target Digital Object Filters */
+                                                                            setFieldValue('targetDigitalObjectFilters', {
+                                                                                ...values.targetDigitalObjectFilters,
+                                                                                [values.targetDigitalObjectFiltersOptions]: [""]
+                                                                            });
+                                                                            /* Set options list value to next attribute in array */
+                                                                            setFieldValue('targetDigitalObjectFiltersOptions', "");
+                                                                        }
+                                                                    }}
+                                                                >
+                                                                    Add filter
+                                                                </button>
+                                                            </Col>
+                                                        </Row>
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Service Description: </p>
+                                                        <Field name="serviceDescription" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Service State: </p>
+                                                        <Field name="serviceState" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Source Code Repository: </p>
+                                                        <Field name="sourceCodeRepository" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Service Availability: </p>
+                                                        <Field name="serviceAvailability" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Code Maintainer: </p>
+                                                        <Field name="codeMaintainer" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Code License: </p>
+                                                        <Field name="codeLicense" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Dependencies: </p>
+                                                        <FieldArray name="dependencies">
+                                                            {({ push, remove }) => (
+                                                                <>
+                                                                    {/* Display all dependencies */}
+                                                                    {values.dependencies.map((_dependency: string, index: number) => {
+                                                                        const key = `dependency_${index}`;
+
+                                                                        return (
+                                                                            <Row key={key} className="pb-2">
+                                                                                <Col md={{ span: 9 }} className="pe-1">
+                                                                                    <Field name={`dependencies.${index}`}
+                                                                                        className={`${styles.formField} w-100`}
+                                                                                    />
+                                                                                </Col>
+                                                                                <Col>
+                                                                                    <FontAwesomeIcon icon={faX}
+                                                                                        onClick={() => remove(index)}
+                                                                                    />
+                                                                                </Col>
+                                                                            </Row>
+                                                                        );
+                                                                    })}
+
+                                                                    {/* Button to add a new dependency */}
+                                                                    <Row className="mt-2">
+                                                                        <Col>
+                                                                            <button type="button"
+                                                                                className={styles.formArrayAddButton}
+                                                                                onClick={() => {
+                                                                                    if (values.dependencies.at(-1) || values.dependencies.length === 0) {
+                                                                                        push("");
+                                                                                    }
+                                                                                }}
+                                                                            >
+                                                                                Add dependency
+                                                                            </button>
+                                                                        </Col>
+                                                                    </Row>
+                                                                </>
+                                                            )}
+                                                        </FieldArray>
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> Support Contact: </p>
+                                                        <Field name="supportContact" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                                <Row className="mt-3">
+                                                    <Col>
+                                                        <p className={`${styles.formFieldTitle} mb-1 fw-lightBold`}> SLA Documentation: </p>
+                                                        <Field name="slaDocumentation" className={`${styles.formField} w-75`} />
+                                                    </Col>
+                                                </Row>
+                                            </Col>
+                                        </Row>
+                                        {/* Action Buttons */}
+                                        <Row>
+                                            <Col>
+                                                <button type="submit"
+                                                    className="primaryButton px-3 py-1"
+                                                >
+                                                    Save
+                                                </button>
+                                            </Col>
+                                        </Row>
+                                    </div>
+                                </Modal.Body>
+                            </Col>
+                        </Row>
+                    </Form>
+                )}
+            </Formik>
+        </Modal>
+    );
+}
+
+export default MASModal;

--- a/src/components/home/components/modals/SourceSystemMappingModal.tsx
+++ b/src/components/home/components/modals/SourceSystemMappingModal.tsx
@@ -14,6 +14,10 @@ import { Dict } from 'global/Types';
 /* Import Styles */
 import styles from 'components/home/home.module.scss';
 
+/* Import Icons */
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faX } from '@fortawesome/free-solid-svg-icons';
+
 /* Import Components */
 import AddSourceSystemForm from '../forms/AddSourceSystemForm';
 import AddMappingMetaForm from '../forms/AddMappingMetaForm';
@@ -255,21 +259,22 @@ const SourceSystemMappingModal = (props: Props) => {
                     <Form className="h-100" onChange={(formField) => CheckOption(formField)}>
                         <Row className="h-100 justify-content-center">
                             <Col md={{ span: 5 }} className="h-100">
-                                <div className="w-100 m-0 p-0 position-relative">
-                                    <button type="button"
-                                        onClick={() => CloseModal()}
-                                        className={`${styles.formModalHeaderButton} position-absolute px-3 border-0 text-white`}
-                                    >
-                                        Dismiss
-                                    </button>
-                                </div>
-
-                                <Modal.Header className={`${styles.formModalHeader} position-relative text-white`}>
-                                    <Modal.Title className={styles.formModalHeaderTitle}>
-                                        {Object.keys(editTarget).length > 0 ?
-                                            `Edit ${chosenTab}` : `Add new ${chosenTab}`
-                                        }
-                                    </Modal.Title>
+                                <Modal.Header className="modalHeader pb-0">
+                                    <Row className="w-100">
+                                        <Col>
+                                            <p className="fw-lightBold">
+                                                {Object.keys(editTarget).length > 0 ?
+                                                    'Edit Machine annotation service' : 'Add new Machine annotation service'
+                                                }
+                                            </p>
+                                        </Col>
+                                        <Col className="col-md-auto pe-0">
+                                            <FontAwesomeIcon icon={faX}
+                                                className="c-pointer"
+                                                onClick={() => CloseModal()}
+                                            />
+                                        </Col>
+                                    </Row>
                                 </Modal.Header>
 
                                 <Modal.Body className={`${styles.formModalBody} bg-white`}>
@@ -287,7 +292,7 @@ const SourceSystemMappingModal = (props: Props) => {
 
                                     <Row className="mt-4">
                                         <Col>
-                                            <button type="submit" className={`${styles.formButton} px-3`}>
+                                            <button type="submit" className="primaryButton px-3 py-1">
                                                 Save
                                             </button>
                                         </Col>
@@ -296,7 +301,7 @@ const SourceSystemMappingModal = (props: Props) => {
                             </Col>
 
                             {secondaryForm &&
-                                <Col md={{ span: 6 }} className="h-100">
+                                <Col md={{ span: 6 }} className="h-100 mt-1">
                                     <Modal.Body className={`${styles.formModalBody} ${styles.secondary} bg-white`}>
                                         <AddMappingForm formValues={values} baseStandard={baseStandard} />
                                     </Modal.Body>

--- a/src/components/home/components/modals/SourceSystemMappingModal.tsx
+++ b/src/components/home/components/modals/SourceSystemMappingModal.tsx
@@ -15,9 +15,9 @@ import { Dict } from 'global/Types';
 import styles from 'components/home/home.module.scss';
 
 /* Import Components */
-import AddSourceSystemForm from './AddSourceSystemForm';
-import AddMappingMetaForm from './AddMappingMetaForm';
-import AddMappingForm from './AddMappingForm';
+import AddSourceSystemForm from '../forms/AddSourceSystemForm';
+import AddMappingMetaForm from '../forms/AddMappingMetaForm';
+import AddMappingForm from '../forms/AddMappingForm';
 
 /* Import API */
 import InsertSourceSystem from 'api/sourceSystem/InsertSourceSystem';
@@ -36,7 +36,7 @@ interface Props {
 };
 
 
-const FormModal = (props: Props) => {
+const SourceSystemMappingModal = (props: Props) => {
     const { modalToggle, chosenTab,
         ToggleModal, UpdateSourceSystems, UpdateMappings } = props;
 
@@ -171,7 +171,7 @@ const FormModal = (props: Props) => {
 
         const mappingRecord = {
             data: {
-                type: 'mapping',
+                type: "mapping",
                 attributes: {
                     name: form.mappingName,
                     description: form.mappingDescription,
@@ -188,6 +188,8 @@ const FormModal = (props: Props) => {
         if (editTarget.mapping) {
             await PatchMapping(mappingRecord, editTarget.mapping.id, KeycloakService.GetToken()).then((mapping) => {
                 UpdateMappings(mapping?.id, mapping);
+            }).catch(error => {
+                console.warn(error);
             });
         } else {
             await InsertMapping(mappingRecord, KeycloakService.GetToken()).then((mapping) => {
@@ -196,6 +198,8 @@ const FormModal = (props: Props) => {
                 }
 
                 UpdateMappings(mapping?.id, mapping);
+            }).catch(error => {
+                console.warn(error);
             });
         }
     }
@@ -265,7 +269,6 @@ const FormModal = (props: Props) => {
                                         {Object.keys(editTarget).length > 0 ?
                                             `Edit ${chosenTab}` : `Add new ${chosenTab}`
                                         }
-
                                     </Modal.Title>
                                 </Modal.Header>
 
@@ -307,4 +310,4 @@ const FormModal = (props: Props) => {
     );
 }
 
-export default FormModal;
+export default SourceSystemMappingModal;

--- a/src/components/home/components/overview/MASOverview.tsx
+++ b/src/components/home/components/overview/MASOverview.tsx
@@ -61,17 +61,22 @@ const MASOverview = (props: Props) => {
 
     /* Table rows */
     const rows: Dict[] = [];
+    let index: number = 0;
 
     machineAnnotationServices.forEach((machineAnnotationService) => {
         rows.push({
+            index: index,
             identifier: machineAnnotationService.id,
             name: machineAnnotationService.name,
             containerImage: machineAnnotationService.containerImage
         });
+
+        index++;
     });
 
     /* Table columns */
     const columns = [
+        { field: 'index', hide: true },
         { field: 'identifier', flex: 0.5, suppressSizeToFit: true, sortable: true },
         { field: 'name', flex: 1, suppressSizeToFit: true, sortable: true },
         { field: 'containerImage', flex: 1, suppressSizeToFit: true, sortable: true },

--- a/src/components/home/components/overview/MASOverview.tsx
+++ b/src/components/home/components/overview/MASOverview.tsx
@@ -15,7 +15,7 @@ import EditButton from './table/EditButton';
 import DeleteButton from './table/DeleteButton';
 
 /* Import API */
-// import DeleteMapping from 'api/mapping/DeleteMapping';
+import DeleteMAS from 'api/mas/DeleteMAS';
 
 
 /* Props Typing */
@@ -35,29 +35,29 @@ const MASOverview = (props: Props) => {
     const machineAnnotationServices = useAppSelector(getMachineAnnotationServices);
 
     /* Function to edit a Mapping */
-    // const EditMapping = (mappingId: string) => {
-    //     const editTarget: EditTarget = {};
+    const EditMachineAnnotationService = (MASId: string) => {
+        const editTarget: EditTarget = {};
 
-    //     /* Fetch Mapping from existing array */
-    //     editTarget.mapping = mappings.find(mapping => mapping.id === mappingId);
+        /* Fetch Mapping from existing array */
+        editTarget.MAS = machineAnnotationServices.find(MAS => MAS.id === MASId);
 
-    //     /* Set edit target */
-    //     dispatch(setEditTarget(editTarget));
+        /* Set edit target */
+        dispatch(setEditTarget(editTarget));
 
-    //     /* Open form modal */
-    //     ToggleModal();
-    // }
+        /* Open form modal */
+        ToggleModal();
+    }
 
-    // /* Function for removing a Mapping */
-    // const RemoveMapping = (mappingId: string) => {
-    //     const confirmed: boolean = window.confirm(`Do you want to delete the Mapping with id: ${mappingId}`);
+    /* Function for removing a Mapping */
+    const RemoveMAS = (MASId: string) => {
+        const confirmed: boolean = window.confirm(`Do you want to delete the Machine annotation service with id: ${MASId}`);
 
-    //     if (confirmed) {
-    //         DeleteMapping(mappingId, KeycloakService.GetToken());
+        if (confirmed) {
+            DeleteMAS(MASId, KeycloakService.GetToken());
 
-    //         UpdateMappings(mappingId);
-    //     }
-    // }
+            UpdateMachineAnnotationServices(MASId);
+        }
+    }
 
     /* Table rows */
     const rows: Dict[] = [];
@@ -80,18 +80,18 @@ const MASOverview = (props: Props) => {
             flex: 0.15,
             suppressSizeToFit: true,
             cellRenderer: EditButton,
-            // cellRendererParams: {
-            //     EditTarget: (mappingId: string) => EditMapping(mappingId)
-            // }
+            cellRendererParams: {
+                EditTarget: (MASId: string) => EditMachineAnnotationService(MASId)
+            }
         },
         {
             field: 'delete',
             flex: 0.2,
             suppressSizeToFit: true,
             cellRenderer: DeleteButton,
-            // cellRendererParams: {
-            //     DeleteTarget: (mappingId: string) => RemoveMapping(mappingId)
-            // }
+            cellRendererParams: {
+                DeleteTarget: (MASId: string) => RemoveMAS(MASId)
+            }
         }
     ];
 

--- a/src/components/home/components/overview/MASOverview.tsx
+++ b/src/components/home/components/overview/MASOverview.tsx
@@ -1,0 +1,101 @@
+/* Import Dependencies */
+import KeycloakService from 'keycloak/Keycloak';
+
+/* Import Store */
+import { useAppSelector, useAppDispatch } from 'app/Hooks';
+import { getMachineAnnotationServices } from 'redux/MAS/MASSlice';
+import { setEditTarget } from 'redux/edit/EditSlice';
+
+/* Import Types */
+import { EditTarget, Dict } from 'global/Types';
+
+/* Import Components */
+import OverviewTable from './table/OverviewTable';
+import EditButton from './table/EditButton';
+import DeleteButton from './table/DeleteButton';
+
+/* Import API */
+// import DeleteMapping from 'api/mapping/DeleteMapping';
+
+
+/* Props Typing */
+interface Props {
+    ToggleModal: Function,
+    UpdateMachineAnnotationServices: Function
+};
+
+
+const MASOverview = (props: Props) => {
+    const { ToggleModal, UpdateMachineAnnotationServices } = props;
+
+    /* Hooks */
+    const dispatch = useAppDispatch();
+
+    /* Base variables */
+    const machineAnnotationServices = useAppSelector(getMachineAnnotationServices);
+
+    /* Function to edit a Mapping */
+    // const EditMapping = (mappingId: string) => {
+    //     const editTarget: EditTarget = {};
+
+    //     /* Fetch Mapping from existing array */
+    //     editTarget.mapping = mappings.find(mapping => mapping.id === mappingId);
+
+    //     /* Set edit target */
+    //     dispatch(setEditTarget(editTarget));
+
+    //     /* Open form modal */
+    //     ToggleModal();
+    // }
+
+    // /* Function for removing a Mapping */
+    // const RemoveMapping = (mappingId: string) => {
+    //     const confirmed: boolean = window.confirm(`Do you want to delete the Mapping with id: ${mappingId}`);
+
+    //     if (confirmed) {
+    //         DeleteMapping(mappingId, KeycloakService.GetToken());
+
+    //         UpdateMappings(mappingId);
+    //     }
+    // }
+
+    /* Table rows */
+    const rows: Dict[] = [];
+
+    machineAnnotationServices.forEach((machineAnnotationService) => {
+        rows.push({
+            identifier: machineAnnotationService.id,
+            name: machineAnnotationService.name,
+            containerImage: machineAnnotationService.containerImage
+        });
+    });
+
+    /* Table columns */
+    const columns = [
+        { field: 'identifier', flex: 0.5, suppressSizeToFit: true, sortable: true },
+        { field: 'name', flex: 1, suppressSizeToFit: true, sortable: true },
+        { field: 'containerImage', flex: 1, suppressSizeToFit: true, sortable: true },
+        {
+            field: 'edit',
+            flex: 0.15,
+            suppressSizeToFit: true,
+            cellRenderer: EditButton,
+            // cellRendererParams: {
+            //     EditTarget: (mappingId: string) => EditMapping(mappingId)
+            // }
+        },
+        {
+            field: 'delete',
+            flex: 0.2,
+            suppressSizeToFit: true,
+            cellRenderer: DeleteButton,
+            // cellRendererParams: {
+            //     DeleteTarget: (mappingId: string) => RemoveMapping(mappingId)
+            // }
+        }
+    ];
+
+    return <OverviewTable columns={columns} rows={rows} />
+}
+
+export default MASOverview;

--- a/src/components/home/components/overview/MappingsOverview.tsx
+++ b/src/components/home/components/overview/MappingsOverview.tsx
@@ -61,17 +61,22 @@ const MappingsOverview = (props: Props) => {
 
     /* Table rows */
     const rows: Dict[] = [];
+    let index: number = 0;
 
     mappings.forEach((mapping) => {
         rows.push({
+            index: index,
             identifier: mapping.id,
             name: mapping.name,
             description: mapping.description
         });
+
+        index++;
     });
 
     /* Table columns */
     const columns = [
+        { field: 'index', hide: true },
         { field: 'identifier', flex: 0.5, suppressSizeToFit: true, sortable: true },
         { field: 'name', flex: 1, suppressSizeToFit: true, sortable: true },
         { field: 'description', flex: 1, suppressSizeToFit: true, sortable: true },

--- a/src/components/home/components/overview/SourceSystemsOverview.tsx
+++ b/src/components/home/components/overview/SourceSystemsOverview.tsx
@@ -70,17 +70,22 @@ const SourceSystemsOverview = (props: Props) => {
 
     /* Table rows */
     const rows: Dict[] = [];
+    let index: number = 0;
 
     sourceSystems.forEach((sourceSystem) => {
         rows.push({
+            index: index,
             identifier: sourceSystem.id,
             name: sourceSystem.name,
             endpoint: sourceSystem.endpoint
         });
+
+        index++;
     });
 
     /* Table columns */
     const columns = [
+        { field: 'index', hide: true },
         { field: 'identifier', flex: 0.5, suppressSizeToFit: true, sortable: true },
         { field: 'name', flex: 1, suppressSizeToFit: true, sortable: true },
         { field: 'endpoint', flex: 1, suppressSizeToFit: true, sortable: true },

--- a/src/components/home/components/overview/table/DeleteButton.tsx
+++ b/src/components/home/components/overview/table/DeleteButton.tsx
@@ -21,7 +21,7 @@ const DeleteButton = (props: Props) => {
 
     return (
         <button type="button"
-            className={`${styles.formButton} px-3 h-75 mt-1 d-flex align-items-center`}
+            className={`${styles.formButton} ${styles.delete} px-3 h-75 mt-1 d-flex align-items-center`}
             onClick={() => DeleteTarget(data.identifier)}
         >
             <FontAwesomeIcon icon={faTrash} />

--- a/src/components/home/components/overview/table/EditButton.tsx
+++ b/src/components/home/components/overview/table/EditButton.tsx
@@ -21,7 +21,7 @@ const EditButton = (props: Props) => {
 
     return (
         <button type="button"
-            className={`${styles.formButton} px-3 h-75 mt-1 d-flex align-items-center`}
+            className={`${styles.formButton} bgc-accent px-3 h-75 mt-1 d-flex align-items-center`}
             onClick={() => EditTarget(data.identifier)}
         >
             <FontAwesomeIcon icon={faEdit} />

--- a/src/components/home/components/overview/table/OverviewTable.tsx
+++ b/src/components/home/components/overview/table/OverviewTable.tsx
@@ -20,10 +20,20 @@ interface Props {
 const OverviewTable = (props: Props) => {
     const { columns, rows } = props;
 
+    const getRowStyle = (params: Dict) => {
+        const data = { ...params.data };
+
+        if (Number(data.index) % 2 === 0) {
+            return { background: "rgb(238, 247, 244)" };
+        }
+
+        return undefined;
+    };
+
     const gridOptions = {
         pagination: true
     }
-    
+
     return (
         <Row className="h-100">
             <Col className="h-100">
@@ -32,6 +42,7 @@ const OverviewTable = (props: Props) => {
                         rowData={rows}
                         columnDefs={columns}
                         gridOptions={gridOptions}
+                        getRowStyle={getRowStyle}
                     />
                 </div>
             </Col>

--- a/src/components/home/home.module.scss
+++ b/src/components/home/home.module.scss
@@ -60,6 +60,7 @@
 
 .formModalBody {
     height: Calc(100% - 50px);
+    overflow-y: scroll;
 }
 
 .formModalBody.secondary {

--- a/src/components/home/home.module.scss
+++ b/src/components/home/home.module.scss
@@ -1,24 +1,41 @@
 /* Custom styling for the Home page */
-
 .addButton {
-    background-color: var(--main-color-dark);
-    border: none;
-    color: white;
-    border-radius: 8px;
-    transition: 0.4s;
+    font-size: 15px;
+    padding: 6px 1.5% !important;
 }
 
 .addButton:hover {
     background-color: var(--main-color);
 }
 
+/* Tabs */
+.tabsList {
+    padding: 0;
+}
+
+.tab {
+    background-color: #E6E2F1;
+    border-radius: 999px;
+    font-size: 15px;
+    padding-left: 2%;
+    padding-right: 2%;
+    margin-right: 1%;
+}
+
+.tab.active {
+    background-color: var(--primary);
+    color: white;
+    font-weight: bold;
+}
+
+.tabPanel {
+    height: Calc(100% - 51px);
+}
 
 /* Overview Tables */
-
 .overviewTable {
     width: 100;
 }
-
 
 /* Form Modal */
 .formModalHeader {
@@ -93,14 +110,19 @@ select option[value="new"] {
 }
 
 .formButton {
-    background-color: white;
-    border: 1px solid var(--main-color);
+    background-color: var(--accent);
+    color: white;
+    border: none;
     border-radius: 8px;
     transition: 0.4s;
 }
 
+.formButton.delete {
+    background-color: var(--denied);
+}
+
 .formButton:hover {
-    background-color: var(--main-color);
+    background-color: var(--primary);
     color: white;
 }
 

--- a/src/components/home/home.module.scss
+++ b/src/components/home/home.module.scss
@@ -21,7 +21,6 @@
 
 
 /* Form Modal */
-
 .formModalHeader {
     height: 50px;
     width: fit-content;
@@ -69,6 +68,28 @@
 select option[value="new"] {
     background-color: var(--main-color);
     color: white;
+}
+
+.formFieldArrayOptionTitle {
+    font-size: 14px;
+}
+
+.formFieldArrayOption {
+    background-color: var(--greyLight);
+}
+
+.formArrayAddButton {
+    background-color: transparent;
+    border: none;
+    color: var(--accent);
+    font-size: 14px;
+}
+
+.formArrayRemoveButton {
+    background-color: transparent;
+    border: none;
+    color: var(--denied);
+    font-size: 14px;
 }
 
 .formButton {

--- a/src/components/landing/Landing.tsx
+++ b/src/components/landing/Landing.tsx
@@ -1,0 +1,44 @@
+/* Import Components */
+import KeycloakService from 'keycloak/Keycloak';
+import { Container, Row, Col } from 'react-bootstrap';
+
+/* Import Webroot */
+import DiSSCoLogo from 'webroot/img/dissco-logo-web.svg';
+
+
+const Landing = () => {
+    return (
+        <Container className="h-100 ">
+            <Row className="h-100 align-items-center">
+                <Col>
+                    <Row>
+                        <Col className="text-center">
+                            <h1> DiSSCo Orchestration Services </h1>
+                        </Col>
+                    </Row>
+                    <Row className="mt-3">
+                        <Col md={{ span: 2, offset: 5 }}>
+                            <img src={DiSSCoLogo} alt="DiSSCo Logo" />
+                        </Col>
+                    </Row>
+                    <Row className="mt-5">
+                        <Col className="text-center">
+                            <p> Please login to continue </p>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col className="d-flex justify-content-center">
+                            <button type="button" className="primaryButton px-3 py-2"
+                                onClick={() => KeycloakService.Login()}
+                            >
+                                Login to DiSSCo
+                            </button>
+                        </Col>
+                    </Row>
+                </Col>
+            </Row>
+        </Container>
+    );
+}
+
+export default Landing;

--- a/src/global/Types.ts
+++ b/src/global/Types.ts
@@ -58,6 +58,24 @@ export interface Mapping {
     }
 }
 
+/* Machine Annotation System (MAS) Type */
+export interface MAS {
+    id: string,
+    name: string,
+    containerImage: string,
+    containerTag: string,
+    targetDigitalObjectFilters: {},
+    serviceDescription: string,
+    serviceState: string,
+    sourceCodeRepository: string,
+    serviceAvailability: string,
+    codeMaintainer: string,
+    codeLicense: string,
+    dependencies: [],
+    supportContact: string,
+    slaDocumentation: string
+}
+
 /* Edit Target Type */
 export interface EditTarget {
     sourceSystem?: SourceSystem,

--- a/src/global/Types.ts
+++ b/src/global/Types.ts
@@ -79,5 +79,6 @@ export interface MAS {
 /* Edit Target Type */
 export interface EditTarget {
     sourceSystem?: SourceSystem,
-    mapping?: Mapping
+    mapping?: Mapping,
+    MAS?: MAS
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import KeycloakService from 'keycloak/Keycloak';
 
 /* Import Styles */
 import 'bootstrap/dist/css/bootstrap.min.css';
+import 'react-tabs/style/react-tabs.css';
 
 /* Import Components */
 import App from './App';

--- a/src/keycloak/Keycloak.ts
+++ b/src/keycloak/Keycloak.ts
@@ -13,14 +13,12 @@ const keycloak = new Keycloak({
 
 const InitKeyCloak = (callback: EmptyCallback) => {
     keycloak.init({
-        onLoad: "login-required",
+        onLoad: "check-sso",
         silentCheckSsoRedirectUri: window.location.origin + "/silent-check-sso.html",
         pkceMethod: "S256"
     })
-        .then((authenticated) => {
-            if (authenticated) {
-                callback();
-            }
+        .then((_authenticated) => {
+            callback();
         })
         .catch(console.error);
 }

--- a/src/redux/MAS/MASSlice.ts
+++ b/src/redux/MAS/MASSlice.ts
@@ -1,0 +1,33 @@
+/* Import Dependencies */
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { RootState } from 'app/Store';
+
+/* Import Types */
+import { MAS } from 'global/Types';
+
+
+export interface MASState {
+    machineAnnotationServices: MAS[];
+}
+
+const initialState: MASState = {
+    machineAnnotationServices: <MAS[]>[]
+};
+
+export const MASSlice = createSlice({
+    name: 'machineAnnotationServices',
+    initialState,
+    reducers: {
+        setMachineAnnotationServices: (state, action: PayloadAction<MAS[]>) => {
+            state.machineAnnotationServices = action.payload;
+        }
+    }
+})
+
+/* Action Creators */
+export const { setMachineAnnotationServices } = MASSlice.actions;
+
+/* Connect with Root State */
+export const getMachineAnnotationServices = (state: RootState) => state.machineAnnotationServices.machineAnnotationServices;
+
+export default MASSlice.reducer;


### PR DESCRIPTION
PR adds an overview tab for the Machine Annotation Services that lists all the current services, as well as Insert, Patch and Delete methods for Machine Annotation Services. Use the modal (apart file from Source Systems and Mappings) to add new machine annotation services. All values are free text at the moment, dependencies is treated as an array, and the Target Digital Object Filters is treated as an object based on the current harmonised terms of openDS.

Adds:
- Overview tab for Machine Annotation Services
- Table to display them in
- New modal with form fields about the Machine Annotation Services
- Insert function for adding new MAS records
- Patch function for updating existing MAS records
- Delete function for removing existing MAS records

Modifies:
- Slight changes to the file hierarchy and names of folders/files to make things more general, and not all focused on Source Systems and Mappings like it was before.