### PR TITLE
Make Keycloak configurable

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 VITE_HANDLE_URL = https://hdl.handle.net/
+VITE_KEYCLOAK_CLIENT = dissco-orchestration-frontend
+VITE_KEYCLOAK_SERVER = https://keycloak.iam.naturalis.io
+VITE_KEYCLOAK_REALM = dissco-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    matrix:
+      include:
+        - image: public.ecr.aws/dissco/${{ github.event.repository.name }}-production
+          keycloak_client: orchestration-service
+          keycloak_server: https://login-demo.dissco.eu/auth
+          keycloak_realm: dissco
+        - image: public.ecr.aws/dissco/${{ github.event.repository.name }}
+          keycloak_client: dissco-orchestration-frontend
+          keycloak_server: https://keycloak.iam.naturalis.io
+          keycloak_realm: dissco-dev
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,16 +7,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    matrix:
-      include:
-        - image: public.ecr.aws/dissco/${{ github.event.repository.name }}-production
-          keycloak_client: orchestration-service
-          keycloak_server: https://login-demo.dissco.eu/auth
-          keycloak_realm: dissco
-        - image: public.ecr.aws/dissco/${{ github.event.repository.name }}
-          keycloak_client: dissco-orchestration-frontend
-          keycloak_server: https://keycloak.iam.naturalis.io
-          keycloak_realm: dissco-dev
+    strategy: 
+      matrix:
+        include:
+          - image: public.ecr.aws/dissco/${{ github.event.repository.name }}-production
+            keycloak_client: orchestration-service
+            keycloak_server: https://login-demo.dissco.eu/auth
+            keycloak_realm: dissco
+          - image: public.ecr.aws/dissco/${{ github.event.repository.name }}
+            keycloak_client: dissco-orchestration-frontend
+            keycloak_server: https://keycloak.iam.naturalis.io
+            keycloak_realm: dissco-dev
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#InteliJ
+.idea

--- a/dockerfile
+++ b/dockerfile
@@ -1,5 +1,5 @@
 # Pull official node image as base
-FROM node:20.15.1-alpine3.19 as build
+FROM node:24-alpine3.21 as build
 
 # Set working directory
 WORKDIR /orchestration-frontend
@@ -8,7 +8,7 @@ WORKDIR /orchestration-frontend
 COPY package.json ./
 COPY package-lock.json ./
 
-RUN npm install npm@10.8.2
+RUN npm install npm@11.6.3
 
 # Copy application
 COPY . ./
@@ -21,11 +21,19 @@ RUN cp 'src/app/GenerateTypes.js' 'src/app/GenerateTypes.cjs'
 RUN rm 'src/app/GenerateTypes.js'
 RUN node 'src/app/GenerateTypes.cjs'
 
+# Set env variables
+ARG VITE_KEYCLOAK_CLIENT
+ENV VITE_KEYCLOAK_CLIENT ${VITE_KEYCLOAK_CLIENT}
+ARG VITE_KEYCLOAK_SERVER
+ENV VITE_KEYCLOAK_SERVER ${VITE_KEYCLOAK_SERVER}
+ARG VITE_KEYCLOAK_REALM
+ENV VITE_KEYCLOAK_REALM ${VITE_KEYCLOAK_REALM}
+
 # Setting app to production build
 RUN npm run build
 
 # Setting up NGINX
-FROM nginx:stable-alpine
+FROM nginx:alpine
 
 COPY --from=build /orchestration-frontend/build /usr/share/nginx/html
 COPY nginx/nginx.conf /etc/nginx/conf.d/default.conf

--- a/src/app/Keycloak.ts
+++ b/src/app/Keycloak.ts
@@ -8,9 +8,9 @@ type Callback = () => Function | void;
 
 /* Create keycloak instance */
 const keycloak = new Keycloak({
-    url: "https://login-demo.dissco.eu/auth",
-    realm: "dissco",
-    clientId: "orchestration-service",
+    url: import.meta.env.VITE_KEYCLOAK_SERVER,
+    realm: import.meta.env.VITE_KEYCLOAK_REALM,
+    clientId: import.meta.env.VITE_KEYCLOAK_CLIENT,
 });
 
 const InitKeyCloak = (callback?: Callback, token?: string) => {


### PR DESCRIPTION
Making Keycloak configurable set that we can run a different Keycloak on dev/acc than on prod.
This means the production image will need to be changed to the `-production` image.
New Keycloak is in env files so that it will still run locally.

Also done some update to the dockerfile, this makes it in line with the updates we did for disscover

https://naturalis.atlassian.net/browse/DD-2554