### PR TITLE
Fix: update POST request for source system ingestion

### DIFF
--- a/src/components/sourceSystem/SourceSystem.tsx
+++ b/src/components/sourceSystem/SourceSystem.tsx
@@ -55,7 +55,8 @@ const SourceSystem = () => {
 
     /* Function to run a Source System Ingestion */
     const RunIngestion = () => {
-        TriggerSourceSystemIngestion(sourceSystem?.['@id'], KeycloakService.GetToken()).then((_response) => { }).catch(error => {
+        const normalizedId = sourceSystem?.['@id']?.replace('https://hdl.handle.net/','');
+        TriggerSourceSystemIngestion(normalizedId, KeycloakService.GetToken()).then((_response) => { }).catch(error => {
             console.warn(error);
         })
     }


### PR DESCRIPTION
The endpoint that should be called is: https://dev-orchestration.dissco.tech/apisource-system/{PREFIX}/{SUFFIX}/run.
Previously the code was calling the endpoint with the full handle instead of only the prefix and suffix.

The request body follows the MasScheduleData schema. Since no fields are required , we currently send an empty object {}. In the future it can be extended if needed.