### PR TITLE
Refactor Source System ingestion to use TanStack/react-query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/react-fontawesome": "^0.2.2",
         "@reduxjs/toolkit": "^2.2.3",
         "@tanstack/match-sorter-utils": "^8.15.1",
+        "@tanstack/react-query": "^5.90.21",
         "@tanstack/react-table": "^8.16.0",
         "ag-grid-community": "^32.3.3",
         "ag-grid-react": "^32.3.3",
@@ -1575,9 +1576,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.21.0.tgz",
-      "integrity": "sha512-xfSkCAchbdG5PnbrKqFWwia4Bi61nH+wm8wLEqfHDyp7Y3dZzgqS2itV8i4gAq9pC2HsTpwyBC6Ds8VHZ96JlA==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -1977,6 +1978,32 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.20",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
+      "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.21.tgz",
+      "integrity": "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.20"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -2933,13 +2960,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3852,9 +3879,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -3872,9 +3899,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -4524,9 +4551,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4706,15 +4733,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -5357,12 +5384,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.28.0.tgz",
-      "integrity": "sha512-HrYdIFqdrnhDw0PqG/AKjAqEqM7AvxCz0DQ4h2W8k6nqmc5uRBYDag0SBxx9iYz5G8gnuNVLzUe13wl9eAsXXg==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -5372,13 +5399,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.28.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
-      "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.21.0",
-        "react-router": "6.28.0"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/react-fontawesome": "^0.2.2",
     "@reduxjs/toolkit": "^2.2.3",
     "@tanstack/match-sorter-utils": "^8.15.1",
+    "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-table": "^8.16.0",
     "ag-grid-community": "^32.3.3",
     "ag-grid-react": "^32.3.3",

--- a/src/api/sourceSystem/TriggerSourceSystemIngestion.ts
+++ b/src/api/sourceSystem/TriggerSourceSystemIngestion.ts
@@ -24,7 +24,9 @@ const TriggerSourceSystemIngestion = async (sourceSystemId?: string, token?: str
 
             response = result.data;
         } catch (error) {
-            console.warn(error);
+            console.error("Error while scheduling ingestion: ", error);
+            /* Rethrow error for useMutation */
+            throw error;
         }
     }
 

--- a/src/components/sourceSystem/SourceSystem.tsx
+++ b/src/components/sourceSystem/SourceSystem.tsx
@@ -21,8 +21,10 @@ import { Header } from 'components/elements/Elements';
 
 /* Import API */
 import GetSourceSystem from 'api/sourceSystem/GetSourceSystem';
-import TriggerSourceSystemIngestion from 'api/sourceSystem/TriggerSourceSystemIngestion';
 import DeleteSourceSystem from 'api/sourceSystem/DeleteSourceSystem';
+
+/* Import Hooks */
+import { useTriggerSourceSystemIngestion } from 'hooks/useTriggerSourceSystemIngestion';
 
 
 const SourceSystem = () => {
@@ -30,6 +32,7 @@ const SourceSystem = () => {
     const dispatch = useAppDispatch();
     const params = useParams();
     const navigate = useNavigate();
+    const runIngestion = useTriggerSourceSystemIngestion();
 
     /* Base variables */
     const sourceSystem = useAppSelector(getSourceSystem);
@@ -52,14 +55,6 @@ const SourceSystem = () => {
             });
         }
     }, []);
-
-    /* Function to run a Source System Ingestion */
-    const RunIngestion = () => {
-        const normalizedId = sourceSystem?.['@id']?.replace('https://hdl.handle.net/','');
-        TriggerSourceSystemIngestion(normalizedId, KeycloakService.GetToken()).then((_response) => { }).catch(error => {
-            console.warn(error);
-        })
-    }
 
     /* Class Names */
     const classTabList = classNames({
@@ -88,7 +83,12 @@ const SourceSystem = () => {
                                     <Col className="col-lg-auto">
                                         <button type="button"
                                             className="primaryButton px-3 py-1"
-                                            onClick={() => RunIngestion()}
+                                            onClick={() => {
+                                                const normalizedId = sourceSystem?.['@id']?.replace('https://hdl.handle.net/', '');
+                                                const KeycloakToken = KeycloakService.GetToken();
+                                                if (!normalizedId || !KeycloakToken) return;
+                                                runIngestion.mutate({ sourceSystemId: normalizedId, token:KeycloakToken });
+                                            }}
                                         >
                                             Run Ingestion
                                         </button>

--- a/src/components/sourceSystem/SourceSystem.tsx
+++ b/src/components/sourceSystem/SourceSystem.tsx
@@ -56,6 +56,17 @@ const SourceSystem = () => {
         }
     }, []);
 
+
+    /** Normalizes the Source System id and retrieves the token, 
+    * to be used in the Tanstack mutation that triggers the ingestion
+    */
+    const triggerIngestion = () => {
+        const normalizedId = sourceSystem?.['@id']?.replace('https://hdl.handle.net/','');
+        const KeycloakToken = KeycloakService.GetToken();
+        if (!normalizedId || !KeycloakToken) return;
+        runIngestion.mutate({ sourceSystemId: normalizedId, token: KeycloakToken });
+    };
+
     /* Class Names */
     const classTabList = classNames({
         'tabsList': true
@@ -83,12 +94,7 @@ const SourceSystem = () => {
                                     <Col className="col-lg-auto">
                                         <button type="button"
                                             className="primaryButton px-3 py-1"
-                                            onClick={() => {
-                                                const normalizedId = sourceSystem?.['@id']?.replace('https://hdl.handle.net/', '');
-                                                const KeycloakToken = KeycloakService.GetToken();
-                                                if (!normalizedId || !KeycloakToken) return;
-                                                runIngestion.mutate({ sourceSystemId: normalizedId, token:KeycloakToken });
-                                            }}
+                                            onClick={triggerIngestion}
                                         >
                                             Run Ingestion
                                         </button>

--- a/src/hooks/useTriggerSourceSystemIngestion.ts
+++ b/src/hooks/useTriggerSourceSystemIngestion.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import TriggerSourceSystemIngestion from 'api/sourceSystem/TriggerSourceSystemIngestion';
+
+type TriggerIngestionVariables = {
+  sourceSystemId: string;
+  token: string;
+};
+
+export const useTriggerSourceSystemIngestion = () => {
+  return useMutation({
+    mutationFn: (variables: TriggerIngestionVariables) => {
+      return TriggerSourceSystemIngestion(variables.sourceSystemId,variables.token);
+    }
+  });
+};

--- a/src/hooks/useTriggerSourceSystemIngestion.ts
+++ b/src/hooks/useTriggerSourceSystemIngestion.ts
@@ -1,15 +1,21 @@
 import { useMutation } from '@tanstack/react-query';
 import TriggerSourceSystemIngestion from 'api/sourceSystem/TriggerSourceSystemIngestion';
 
-type TriggerIngestionVariables = {
+type TriggerIngestionParams = {
   sourceSystemId: string;
   token: string;
 };
 
+/**
+* Hook that handles the state of a Source System ingestion when a POST request is made.
+* It is used by the "Run Ingestion" button.
+* @returns TanStack mutation object with the isError or isSuccess state. In the error state, the error is also available
+* via the error property
+*/
 export const useTriggerSourceSystemIngestion = () => {
   return useMutation({
-    mutationFn: (variables: TriggerIngestionVariables) => {
-      return TriggerSourceSystemIngestion(variables.sourceSystemId,variables.token);
+    mutationFn: (variables: TriggerIngestionParams) => {
+      return TriggerSourceSystemIngestion(variables.sourceSystemId, variables.token);
     }
   });
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import ReactDOM from 'react-dom/client';
 import KeycloakService from 'app/Keycloak';
 import { Provider } from 'react-redux';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 
 /* Import Store */
 import { setupStore } from './app/Store';
@@ -15,7 +16,10 @@ import 'react-tabs/style/react-tabs.css';
 import App from './App';
 
 
+/* Define axios base url */
 axios.defaults.baseURL = `${window.location.protocol}//${window.location.hostname}${window.location.port ? ':' + window.location.port : ''}/api`;
+/* Set up queryClient for TanStack query */
+const queryClient = new QueryClient();
 
 const RenderRoot = () => {
   const root = ReactDOM.createRoot(
@@ -23,9 +27,11 @@ const RenderRoot = () => {
   );
 
   root.render(
-    <Provider store={setupStore()}>
-      <App />
-    </Provider>
+    <QueryClientProvider client={queryClient}>
+      <Provider store={setupStore()}>
+        <App/>
+      </Provider>
+    </QueryClientProvider >
   );
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     alias: {
       api: '/src/api',
       app: '/src/app',
+      hooks: '/src/hooks',
       components: '/src/components',
       "redux-store": '/src/redux-store',
       sources: '/src/sources',


### PR DESCRIPTION
In this PR we are moving from Axios to Tanstack/react query .This allows us to move from just an HTTP client to a state management library that tracks loading, success and error states. Also, we are complying with the DiSSCover and ARISE standards.

What was changed:
- Created a hook useTriggerSourceSystemIngestion
-  Updated the component to call the hook for the ingestion
- Errors are thrown to TanStack for it to handle them

What was not addressed:
This change strictly refactors the ingestion POST request to use TanStack. Toast notifications and error handling are intentionally excluded from this PR and will be addressed in a separate PR.

Note: The ingestion endpoint makes a POST request that schedules a backend job. In this case we are using useMutation hook, because we don’t need to fetch the data and cache the response, but instead we want it to trigger a run and schedule a job in the server.