### PR TITLE
Add simple missing fields in the create MAS flow

### DIFF
--- a/src/components/formBuilder/SubmitFunctions.ts
+++ b/src/components/formBuilder/SubmitFunctions.ts
@@ -141,7 +141,12 @@ const SubmitMas = async (form: Dict, editTarget: EditTarget) => {
                 },
                 "ods:slaDocumentation": form.masSlaDocumentation,
                 "ods:maxReplicas": form.masMaxReplicas,
-                "ods:batchingPermitted": form.masBatchingPermitted
+                "ods:batchingPermitted": form.masBatchingPermitted,
+                "schema:creativeWorkStatus": form.masCreativeWorkStatus,
+                "schema:programmingLanguage": form.masProgrammingLanguage,
+                "ods:timeToLive": form.masTimeToLive,
+                "ods:dependency": form.masDependency,
+                "ods:isIngestionCompatible": form.masIsIngestionCompatible,
             }
         }
     };

--- a/src/components/mas/components/MasForm.tsx
+++ b/src/components/mas/components/MasForm.tsx
@@ -33,6 +33,8 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
             initialValuesFields[field?.alias ?? field.name] = mas?.['schema:maintainer']?.['schema:identifier'];
         } else if (field.name === 'schema:ContactPoint') {
             initialValuesFields[field?.alias ?? field.name] = mas?.['schema:ContactPoint']?.['schema:url'];
+        } else if (field.type === 'multiValueTextField') {
+            initialValuesFields[field?.alias ?? field.name] =mas?.[field.name as keyof typeof mas] ?? [];
         } else {
             initialValuesFields[field?.alias ?? field.name] = mas?.[field.name as keyof typeof mas] ?? (field.defaultValue ?? '');
         }

--- a/src/sources/formFields/MasFields.json
+++ b/src/sources/formFields/MasFields.json
@@ -71,6 +71,33 @@
             "type": "number",
             "defaultValue": 1
         },
+                {
+            "name": "schema:creativeWorkStatus",
+            "alias": "masCreativeWorkStatus",
+            "type": "text"
+        },
+        {
+            "name": "schema:programmingLanguage",
+            "alias": "masProgrammingLanguage",
+            "type": "text"
+        },
+        {
+            "name": "ods:timeToLive",
+            "alias": "masTimeToLive",
+            "type": "number",
+            "defaultValue": 3600
+        },
+        {
+            "name": "ods:dependency",
+            "alias": "masDependency",
+            "type": "multiValueTextField"
+        },
+        {
+            "name": "ods:isIngestionCompatible",
+            "alias": "masIsIngestionCompatible",
+            "type": "boolean",
+            "defaultValue": false
+        },
         {
             "name": "ods:batchingPermitted",
             "alias": "masBatchingPermitted",


### PR DESCRIPTION
In this PR, new fields that were missing were added in the form, when the user creates a new MAS. The fields that are added are simple text, boolean, number and multiValueTextField. The new fields are the following:
- creativeWorkStatus: string
- programmingLanguage: string
- dependency: array of strings (multiValueTextField)
- timeToLive: int
- isIngestionCompatible: boolean

The additional fields that are currently missing (hasEnvironmentalVariables & 
hasSecretVariables) will be added in a new PR, because new components will be created.

https://naturalis.atlassian.net/browse/DD-2881