### PR TITLE
Feature/visual required fields mas

### DIFF
--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -44,21 +44,21 @@ const DetermineFormField = (fieldName: string, visibleName: string, fieldType: s
         case 'text':
             return <InputField name={fieldName} visibleName={visibleName} required={required} />;
         case 'textarea':
-            return <InputTextArea name={fieldName} visibleName={visibleName} />;
+            return <InputTextArea name={fieldName} visibleName={visibleName} required={required} />;
         case 'number':
             return <InputField name={fieldName} visibleName={visibleName} required={required} />;
         case 'boolean':
-            return <BooleanField name={fieldName} visibleName={visibleName} />;
+            return <BooleanField name={fieldName} visibleName={visibleName} required={required} />;
         case 'select':
             return <SelectField name={fieldName} visibleName={visibleName} options={options} required={required} />;
         case 'array':
-            return <ArrayField name={fieldName} visibleName={visibleName} />;
+            return <ArrayField name={fieldName} visibleName={visibleName} required={required} />;
         case 'dataMappingSelect':
             return <DataMappingSelect required={required} />;
         case 'dataMapping':
             return <DataMappingField name={fieldName} visibleName={visibleName} />;
         case 'masFilters':
-            return <MasFiltersField name={fieldName} visibleName={visibleName} />;
+            return <MasFiltersField name={fieldName} visibleName={visibleName} required={required} />;
         case 'multiValueTextField':
             return <MultiValueTextField name={fieldName} visibleName={visibleName} required={required} />;
         default:

--- a/src/components/formBuilder/formFields/ArrayField.tsx
+++ b/src/components/formBuilder/formFields/ArrayField.tsx
@@ -17,17 +17,23 @@ import { faX } from "@fortawesome/free-solid-svg-icons";
 interface Props {
     name: string,
     visibleName: string,
-    formValues?: Dict
+    formValues?: Dict,
+    /* Visual indicator for required fields (no form validation logic) */
+    required?: boolean
 };
 
 
 const ArrayField = (props: Props) => {
-    const { name, visibleName, formValues } = props;
+    const { name, visibleName, formValues, required } = props;
 
     return (
         <Row className="mt-2">
             <Col>
-                <p className="ms-1 mb-1"> {`${MakeJsonPathReadableString(visibleName)}:`} </p>
+                <p className="ms-1 mb-1">
+                    {MakeJsonPathReadableString(visibleName)}
+                    {":"}
+                    {required && <span className="text-danger"> * </span>}
+                </p>
 
                 <FieldArray name={name}>
                     {({ push, remove }) => (

--- a/src/components/formBuilder/formFields/BooleanField.tsx
+++ b/src/components/formBuilder/formFields/BooleanField.tsx
@@ -9,17 +9,23 @@ import { MakeJsonPathReadableString } from "app/Utilities";
 /* Props Typing */
 interface Props {
     name: string,
-    visibleName: string
+    visibleName: string,
+    /* Visual indicator for required fields (no form validation logic) */
+    required?: boolean
 };
 
 
 const BooleanField = (props: Props) => {
-    const { name, visibleName } = props;
+    const { name, visibleName, required } = props;
 
     return (
         <Row key={name} className="mt-2">
             <Col className="col-lg-auto">
-                <p className="ms-1 mb-1"> {`${MakeJsonPathReadableString(visibleName)}:`} </p>
+                <p className="ms-1 mb-1">
+                    {MakeJsonPathReadableString(visibleName)}
+                    {":"}
+                    {required && <span className="text-danger"> * </span>}
+                </p>
             </Col>
             <Col>
                 <Field name={name}

--- a/src/components/formBuilder/formFields/InputTextArea.tsx
+++ b/src/components/formBuilder/formFields/InputTextArea.tsx
@@ -9,17 +9,23 @@ import { MakeJsonPathReadableString } from "app/Utilities";
 /* Props Typing */
 interface Props {
     name: string,
-    visibleName: string
+    visibleName: string,
+    /* Visual indicator for required fields (no form validation logic) */
+    required?: boolean
 };
 
 
 const InputTextArea = (props: Props) => {
-    const { name, visibleName } = props;
+    const { name, visibleName, required } = props;
 
     return (
         <Row key={name} className="mt-2">
             <Col>
-                <p className="ms-1 mb-1"> {`${MakeJsonPathReadableString(visibleName)}:`} </p>
+                <p className="ms-1 mb-1">
+                    {MakeJsonPathReadableString(visibleName)}
+                    {":"}
+                    {required && <span className="text-danger"> * </span>}
+                </p>
                 <Field name={name}
                     as="textarea"
                     rows="4"

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -21,12 +21,14 @@ interface Props {
     name: string,
     visibleName: string,
     formValues?: Dict,
-    SetFieldValue?: Function
+    SetFieldValue?: Function,
+    /* Visual indicator for required fields (no form validation logic) */
+    required?: boolean
 };
 
 
 const MasFiltersField = (props: Props) => {
-    const { name, visibleName, formValues, SetFieldValue } = props;
+    const { name, visibleName, formValues, SetFieldValue, required } = props;
 
     /* Base variables */
     const harmonisedAttributes: Dict = cloneDeep(HarmonisedAttributes);
@@ -36,7 +38,11 @@ const MasFiltersField = (props: Props) => {
             <Col>
                 <Row>
                     <Col>
-                        <p className="ms-1 mb-1"> {`${MakeJsonPathReadableString(visibleName)}:`} </p>
+                        <p className="ms-1 mb-1">
+                            {MakeJsonPathReadableString(visibleName)}
+                            {":"}
+                            {required && <span className="text-danger"> * </span>}
+                        </p>
                     </Col>
                 </Row>
                 <Row className="mb-2">

--- a/src/components/mas/components/MasForm.tsx
+++ b/src/components/mas/components/MasForm.tsx
@@ -11,18 +11,18 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
     const initialValuesFields: Dict = {};
 
     /* Required fields for this form */
-    const requiredFields = [
+    const requiredFields = new Set([
         'schema:name',
         'ods:containerImage',
         'ods:containerTag',
         'ods:hasTargetDigitalObjectFilter',
         'ods:batchingPermitted'
-    ];
+    ]);
 
     /* Generate MAS form fields */
     MasFields.fields.forEach((field) => {
         /* Check if this field should be marked as required */
-        const isRequired = requiredFields.includes(field.name);
+        const isRequired = requiredFields.has(field.name);
 
         /* Push to form fields, if not hidden */
         const formField = DetermineFormField(field.alias ?? field.name, field.name, field.type, 'options' in field ? field.options : undefined, isRequired);

--- a/src/components/mas/components/MasForm.tsx
+++ b/src/components/mas/components/MasForm.tsx
@@ -10,7 +10,7 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
     const formFields: JSX.Element[] = [];
     const initialValuesFields: Dict = {};
 
-    /* Required fields for this form */
+    /* Required fields for the MAS form */
     const requiredFields = new Set([
         'schema:name',
         'ods:containerImage',

--- a/src/components/mas/components/MasForm.tsx
+++ b/src/components/mas/components/MasForm.tsx
@@ -10,10 +10,22 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
     const formFields: JSX.Element[] = [];
     const initialValuesFields: Dict = {};
 
+    /* Required fields for this form */
+    const requiredFields = [
+        'schema:name',
+        'ods:containerImage',
+        'ods:containerTag',
+        'ods:hasTargetDigitalObjectFilter',
+        'ods:batchingPermitted'
+    ];
+
     /* Generate MAS form fields */
     MasFields.fields.forEach((field) => {
+        /* Check if this field should be marked as required */
+        const isRequired = requiredFields.includes(field.name);
+
         /* Push to form fields, if not hidden */
-        const formField = DetermineFormField(field.alias ?? field.name, field.name, field.type);
+        const formField = DetermineFormField(field.alias ?? field.name, field.name, field.type, 'options' in field ? field.options : undefined, isRequired);
 
         if (formField) {
             formFields.push(formField);
@@ -34,7 +46,7 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
         } else if (field.name === 'schema:ContactPoint') {
             initialValuesFields[field?.alias ?? field.name] = mas?.['schema:ContactPoint']?.['schema:url'];
         } else if (field.type === 'multiValueTextField') {
-            initialValuesFields[field?.alias ?? field.name] =mas?.[field.name as keyof typeof mas] ?? [];
+            initialValuesFields[field?.alias ?? field.name] = mas?.[field.name as keyof typeof mas] ?? [];
         } else {
             initialValuesFields[field?.alias ?? field.name] = mas?.[field.name as keyof typeof mas] ?? (field.defaultValue ?? '');
         }


### PR DESCRIPTION
In this PR, the required fields for the form when the user creates a new MAS, are marked with a visual indicator that they need to be filled by the user. There is no form validation added, a new PR will open for the form validation. The fields that are required for the create new MAS flow, according to this [schema](https://schemas.dissco.tech/schemas/developer-schema/machine-annotation-service/latest/machine-annotation-service-request.json) are:
- "schema:name"
- "ods:containerImage"
- "ods:containerTag"
- "ods:batchingPermitted"
- "ods:hasTargetDigitalObjectFilter"

<img width="748" height="962" alt="image" src="https://github.com/user-attachments/assets/dddc3cec-2542-402e-903f-41b396a343ca" />

<img width="748" height="962" alt="image" src="https://github.com/user-attachments/assets/5a63c79a-09e8-4522-9ae9-9110d1a12127" />
