### PR TITLE
Feature/form validation mas

### DIFF
--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -260,6 +260,14 @@ const FormBuilder = () => {
                             'dataMappingSourceDataStandard'
                         ];
 
+                        const requiredFieldsMAS = [
+                            'masName',
+                            'masContainerImage',
+                            'masContainerTag',
+                            'ods:hasTargetDigitalObjectFilter',
+                            'masBatchingPermitted'
+                        ];
+
                         if (location.pathname.includes('source-system') && formPage === 0) {
                             requiredFieldsSourceSystem.forEach((requiredFieldSourceSystem) => {
                                 if (!values[requiredFieldSourceSystem]) {
@@ -272,6 +280,14 @@ const FormBuilder = () => {
                             requiredFieldsDataMapping.forEach((requiredFieldDataMapping) => {
                                 if (!values[requiredFieldDataMapping]) {
                                     errors[requiredFieldDataMapping] = 'Required';
+                                }
+                            });
+                        }
+
+                        if (location.pathname.includes('mas')) {
+                            requiredFieldsMAS.forEach((requiredFieldsMAS) => {
+                                if (!values[requiredFieldsMAS]) {
+                                    errors[requiredFieldsMAS] = 'Required';
                                 }
                             });
                         }

--- a/src/components/formBuilder/formFields/BooleanField.tsx
+++ b/src/components/formBuilder/formFields/BooleanField.tsx
@@ -1,5 +1,5 @@
 /* Import Dependencies */
-import { Field } from "formik";
+import { Field, ErrorMessage } from "formik";
 import { Row, Col } from 'react-bootstrap';
 
 /* Import Utitilies */
@@ -31,6 +31,9 @@ const BooleanField = (props: Props) => {
                 <Field name={name}
                     type="checkbox"
                 />
+                <ErrorMessage name={name}>
+                    {(msg) => <div className="text-danger small mt-1">{msg}</div>}
+                </ErrorMessage>
             </Col>
         </Row>
     );

--- a/src/components/formBuilder/formFields/DataMappingFilter.tsx
+++ b/src/components/formBuilder/formFields/DataMappingFilter.tsx
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import { Row, Col } from 'react-bootstrap';
-import { FieldArray, Field } from 'formik';
+import { FieldArray, Field, ErrorMessage } from 'formik';
 
 /* Import Types */
 import { Dict } from 'app/Types';
@@ -69,7 +69,15 @@ const DataMappingFilter = (props: Props) => {
                                             <Col md={{ span: 9 }} className="pe-0">
                                                 <Field name={`ods:hasTargetDigitalObjectFilter.${objectFilter}.${index}`}
                                                     className="formField w-100 mb-2"
+                                                    validate={(value: string) => {
+                                                        if (!value || value.trim() === '') {
+                                                            return 'Required';
+                                                        }
+                                                    }}
                                                 />
+                                                <ErrorMessage name={`${name}.${objectFilter}.${index}`}>
+                                                    {(msg) => <div className="text-danger small mt-1">{msg}</div>}
+                                                </ErrorMessage>
                                             </Col>
                                             <Col>
                                                 <FontAwesomeIcon icon={faX}

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -1,6 +1,6 @@
 /* Import Dependencies */
 import { Row, Col } from 'react-bootstrap';
-import { Field, ErrorMessage, useFormikContext } from 'formik';
+import { Field, ErrorMessage } from 'formik';
 import { cloneDeep } from 'lodash';
 
 /* Import Utilities */

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -1,7 +1,8 @@
 /* Import Dependencies */
 import { Row, Col } from 'react-bootstrap';
-import { Field } from 'formik';
+import { Field, ErrorMessage, useFormikContext } from 'formik';
 import { cloneDeep } from 'lodash';
+import { useEffect } from 'react';
 
 /* Import Utilities */
 import { MakeJsonPathReadableString } from 'app/Utilities';
@@ -29,6 +30,11 @@ interface Props {
 
 const MasFiltersField = (props: Props) => {
     const { name, visibleName, formValues, SetFieldValue, required } = props;
+    const { validateForm } = useFormikContext();
+
+    useEffect(() => {
+        validateForm();
+    }, [formValues?.[name], validateForm]);
 
     /* Base variables */
     const harmonisedAttributes: Dict = cloneDeep(HarmonisedAttributes);
@@ -36,6 +42,21 @@ const MasFiltersField = (props: Props) => {
     return (
         <Row className="mt-2">
             <Col>
+                <Field
+                    name={name}
+                    validate={(value: Dict) => {
+                        // Check if filters exist
+                        if (!value || Object.keys(value).length === 0) {
+                            return 'Required';
+                        }
+                        // Check if the filter is selected but no values are added
+                        if (formValues?.targetDigitalObjectFiltersOptions && formValues.targetDigitalObjectFiltersOptions !== "") {
+                            return 'Required';
+                        }
+                    }}
+                >
+                    {() => null}
+                </Field>
                 <Row>
                     <Col>
                         <p className="ms-1 mb-1">
@@ -43,6 +64,13 @@ const MasFiltersField = (props: Props) => {
                             {":"}
                             {required && <span className="text-danger"> * </span>}
                         </p>
+                        {/* Only render top level(string) errors. Nested errors are handled at input level*/}
+                        <ErrorMessage name={name}>
+                            {(msg) => {
+                                if (typeof msg !== 'string') return null;
+                                return <div className="text-danger small mt-1">{msg}</div>;
+                            }}
+                        </ErrorMessage>
                     </Col>
                 </Row>
                 <Row className="mb-2">

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -2,7 +2,6 @@
 import { Row, Col } from 'react-bootstrap';
 import { Field, ErrorMessage, useFormikContext } from 'formik';
 import { cloneDeep } from 'lodash';
-import { useEffect } from 'react';
 
 /* Import Utilities */
 import { MakeJsonPathReadableString } from 'app/Utilities';
@@ -30,11 +29,6 @@ interface Props {
 
 const MasFiltersField = (props: Props) => {
     const { name, visibleName, formValues, SetFieldValue, required } = props;
-    const { validateForm } = useFormikContext();
-
-    useEffect(() => {
-        validateForm();
-    }, [formValues?.[name], validateForm]);
 
     /* Base variables */
     const harmonisedAttributes: Dict = cloneDeep(HarmonisedAttributes);

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -42,21 +42,6 @@ const MasFiltersField = (props: Props) => {
     return (
         <Row className="mt-2">
             <Col>
-                <Field
-                    name={name}
-                    validate={(value: Dict) => {
-                        // Check if filters exist
-                        if (!value || Object.keys(value).length === 0) {
-                            return 'Required';
-                        }
-                        // Check if the filter is selected but no values are added
-                        if (formValues?.targetDigitalObjectFiltersOptions && formValues.targetDigitalObjectFiltersOptions !== "") {
-                            return 'Required';
-                        }
-                    }}
-                >
-                    {() => null}
-                </Field>
                 <Row>
                     <Col>
                         <p className="ms-1 mb-1">
@@ -64,13 +49,6 @@ const MasFiltersField = (props: Props) => {
                             {":"}
                             {required && <span className="text-danger"> * </span>}
                         </p>
-                        {/* Only render top level(string) errors. Nested errors are handled at input level*/}
-                        <ErrorMessage name={name}>
-                            {(msg) => {
-                                if (typeof msg !== 'string') return null;
-                                return <div className="text-danger small mt-1">{msg}</div>;
-                            }}
-                        </ErrorMessage>
                     </Col>
                 </Row>
                 <Row className="mb-2">
@@ -97,6 +75,13 @@ const MasFiltersField = (props: Props) => {
                     <Col className="col-lg-auto">
                         <Field name="targetDigitalObjectFiltersOptions"
                             as="select"
+                            validate={() => {
+                                const addedFilters = formValues?.['ods:hasTargetDigitalObjectFilter'];
+
+                                if (Object.keys(addedFilters).length === 0) {
+                                    return 'Required';
+                                }
+                            }}
                         >
                             <option value="" disabled={true}> Select a harmonised attribute </option>
 
@@ -106,6 +91,9 @@ const MasFiltersField = (props: Props) => {
                                 }
                             })}
                         </Field>
+                        <ErrorMessage name="targetDigitalObjectFiltersOptions">
+                            {(msg) => <div className="text-danger small mt-1">{msg}</div>}
+                        </ErrorMessage>
                     </Col>
                     <Col>
                         <button type="button"

--- a/src/sources/formFields/MasFields.json
+++ b/src/sources/formFields/MasFields.json
@@ -71,7 +71,7 @@
             "type": "number",
             "defaultValue": 1
         },
-                {
+        {
             "name": "schema:creativeWorkStatus",
             "alias": "masCreativeWorkStatus",
             "type": "text"


### PR DESCRIPTION
In this Pr the fields in the form that are marked as required based on the [relevant JSON schema](https://schemas.dissco.tech/schemas/developer-schema/machine-annotation-service/latest/machine-annotation-service-request.json), are validated and the user cannot save the form if they are are not filled.

In detail:
- In the "FormBuilder.tsx" the required fields for the MAS are specified. 
- In the "MasFiltersField.tsx" the validation is done on the ods:hasTargetDigitalObjectFilter field because this is the one that is getting submitted in the form.  The targetDigitalObjectFiltersOptions is only used to store the current dropdown selection before it is added. 
- In the "DataMappingFilter.tsx" the validation of the user's input value is validated.
- Therefore, the form is now invalid when no filters are added or when a filter has no values


<img width="546" height="943" alt="image" src="https://github.com/user-attachments/assets/49036593-c1e5-4863-84f0-07369f2a2c8d" />

<img width="546" height="943" alt="image" src="https://github.com/user-attachments/assets/1a111253-fe2c-4ead-afdb-fe15c37d986d" />

<img width="546" height="943" alt="image" src="https://github.com/user-attachments/assets/717d708b-f3d2-4e81-bbb5-f1aff21f0efd" />
