### PR TITLE
Removed topicName

### DIFF
--- a/src/components/formBuilder/SubmitFunctions.ts
+++ b/src/components/formBuilder/SubmitFunctions.ts
@@ -127,7 +127,6 @@ const SubmitMas = async (form: Dict, editTarget: EditTarget) => {
                 "ods:containerImage": form.masContainerImage,
                 "ods:containerTag": form.masContainerTag,
                 "ods:hasTargetDigitalObjectFilter": targetDigitalObjectFilters,
-                "ods:topicName": form.masTopicName,
                 "schema:description": form.masServiceDescription,
                 "schema:codeRepository": form.masSourceCodeRepository,
                 "ods:serviceAvailability": form.masServiceAvailability,

--- a/src/components/mas/Mas.tsx
+++ b/src/components/mas/Mas.tsx
@@ -115,7 +115,6 @@ const Mas = () => {
                                         name: mas['schema:name'],
                                         containerImage: mas['ods:containerImage'],
                                         containerTag: mas['ods:containerTag'],
-                                        topicName: mas['ods:topicName'],
                                         sourceCodeRepository: mas['schema:codeRepository'],
                                         codeMaintainer: mas['schema:maintainer']?.['schema:identifier'],
                                         codeLicense: mas['schema:license'],

--- a/src/sources/formFields/MasFields.json
+++ b/src/sources/formFields/MasFields.json
@@ -26,11 +26,6 @@
             "defaultValue": ""
         },
         {
-            "name": "ods:topicName",
-            "alias": "masTopicName",
-            "type": "text"
-        },
-        {
             "name": "schema:description",
             "alias": "masServiceDescription",
             "type": "textarea"


### PR DESCRIPTION
The topic name should be managed internally in the backend, therefore there should be no field for the user to fill in the MAS form. 

Changes:
- The topic name field is excluded from the form fields in the MAS flow
- The topic name is not sent to the backend through the payload
- The topic name is excluded in the overview page of the MAS

https://naturalis.atlassian.net/browse/DD-3083

<img width="1469" height="983" alt="image" src="https://github.com/user-attachments/assets/01ab36f0-434a-4f70-bca3-05bfec4dba4f" />

<img width="612" height="957" alt="image" src="https://github.com/user-attachments/assets/43739968-b8c3-414b-a584-4b6afd64bec3" />

<img width="612" height="957" alt="image" src="https://github.com/user-attachments/assets/51bcecda-7747-48f7-8ed9-b660f7f03393" />