### PR TITLE
Bug/update mas

### DIFF
--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Utilities */
-import { RetrieveEnvVariable } from 'app/Utilities';
+import { KebabToCamel, RetrieveEnvVariable } from 'app/Utilities';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
@@ -90,14 +90,12 @@ const FormBuilder = () => {
             const route = location.pathname.split('/', 2)[1];
             const id = `${location.pathname.split('/', 3)[2]}/${location.pathname.split('/', 4)[3]}`;
 
-            if (!editTarget?.[route as keyof typeof editTarget]) {
                 /* Set edit target */
                 DefineEditTarget(route, id).then((editTarget) => {
                     dispatch(setEditTarget(editTarget));
                 }).catch(error => {
                     console.warn(error);
                 });
-            }
         } else {
             dispatch(setEditTarget(undefined));
         }

--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -8,7 +8,7 @@ import classNames from 'classnames';
 import { Container, Row, Col } from 'react-bootstrap';
 
 /* Import Utilities */
-import { KebabToCamel, RetrieveEnvVariable } from 'app/Utilities';
+import { RetrieveEnvVariable } from 'app/Utilities';
 
 /* Import Store */
 import { useAppSelector, useAppDispatch } from 'app/Hooks';
@@ -84,7 +84,7 @@ const FormBuilder = () => {
     const formTemplates: JSX.Element[] = [];
     let initialValues: Dict = {};
 
-    /* OnLoad: check if route is edit and edit target is present and valid */
+    /* OnLoad: always fetch fresh edit target for edit routes, clear it otherwise */
     useEffect(() => {
         if (location.pathname.includes('edit')) {
             const route = location.pathname.split('/', 2)[1];


### PR DESCRIPTION
The initial issue was related to the frontend not updating correctly after editing (PATCH) a MAS. The form was reusing a cached editTarget, resulting in outdated data being displayed.

This behavior was originally caused by a mismatch between route pathnames (source-system, data-mapping) and the corresponding editTarget keys (sourceSystem, dataMapping). After resolving this pathname issue, additional problems came up.

When editing either a source system, a data mapping or a mas:
- Editing a different record of the same type in sequence resulted in the form being pre-filled with the previous editTarget.
- Editing the same record multiple times did not trigger a new fetch, causing the form to display outdated data.

These issues were caused by the following condition `if (!editTarget?.[route as keyof typeof editTarget])` 

This check only verified whether an editTarget existed for a given type, but did not ensure that it corresponded to the correct record (id) or that the data was up to date. An intermediate fix that included an id comparison resolved the first issue (switching between records), but did not address the second issue (re-editing the same record with updated data).

For the final solution, the caching condition has been removed. The application now:
- Always fetches fresh data when entering an edit route
- Clears the editTarget when leaving the edit route

https://naturalis.atlassian.net/browse/DD-2483