### PR TITLE
Updated IDCard fields for "undefined" field values

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -248,11 +248,6 @@ p {
   resize: none;
 }
 
-.idCardValue {
-  white-space: pre-line;
-}
-
-
 /* Bootstrap class overwrite */
 .tab-content {
   height: Calc(100% - 41px);

--- a/src/app/Utilities.ts
+++ b/src/app/Utilities.ts
@@ -120,25 +120,11 @@ const ConvertToTypedValue = (value: string) => {
     return value;
 };
 
-/**
- * Function that formats an array of strings into newline seperated strings for better UI display.
- * @param value Array of strings to be formatted
- * @returns Newline-separated string
- */
-const arrayToNewline = (value: any): string => {
-    if (Array.isArray(value)) {
-        return value.join('\n');
-    }
-
-    return String(value);
-};
-
 export {
     Capitalize,
     MakeJsonPathReadableString,
     ParseString,
     ReparseString,
     RetrieveEnvVariable,
-    ConvertToTypedValue,
-    arrayToNewline
+    ConvertToTypedValue
 };

--- a/src/components/general/IDCard/IDCard.tsx
+++ b/src/components/general/IDCard/IDCard.tsx
@@ -4,15 +4,11 @@ import { Row, Col, Card } from 'react-bootstrap';
 /* Import Types */
 import { Dict } from 'app/Types';
 
-/* Import Utilities */
-import { arrayToNewline } from 'app/Utilities';
-
 /* Props Typing */
 interface Props {
     identifier: string,
     IDCardProperties: Dict
 };
-
 
 const IDCard = (props: Props) => {
     const { identifier, IDCardProperties } = props;
@@ -26,6 +22,7 @@ const IDCard = (props: Props) => {
                             <Col className="fs-4 c-secondary fw-lightBold">
                                 <p> ID Card </p>
                             </Col>
+
                             <Col className="fs-4 col-md-auto fw-lightBold">
                                 <p> {identifier} </p>
                             </Col>
@@ -33,17 +30,25 @@ const IDCard = (props: Props) => {
                     </Card.Subtitle>
 
                     <div className="flex-grow-1">
-                        <div className="mh-100 ">
+                        <div className="mh-100">
                             <Row className="h-100">
                                 <Col className="h-100 d-flex flex-column justify-content-between">
-                                    {Object.keys(IDCardProperties).map((propertyKey) => {
+                                    {Object.keys(IDCardProperties).filter((propertyKey) => {
+                                        const propertyValue = IDCardProperties[propertyKey];
+                                        return propertyValue !== undefined;
+                                    }).map((propertyKey) => {
                                         const propertyValue = IDCardProperties[propertyKey];
 
                                         return (
                                             <Row key={propertyKey} className="my-2">
                                                 <Col className="text-overflow">
                                                     <p className="fw-lightBold"> {propertyKey} </p>
-                                                    <p className='idCardValue'>{arrayToNewline(propertyValue)} </p>
+                                                    {[propertyValue].flat().map((value, index) => {
+                                                        
+                                                        return (
+                                                            <p key={index} > {String(value)} </p>
+                                                        );
+                                                    })}
                                                 </Col>
                                             </Row>
                                         );

--- a/src/components/general/IDCard/IDCard.tsx
+++ b/src/components/general/IDCard/IDCard.tsx
@@ -46,7 +46,7 @@ const IDCard = (props: Props) => {
                                                     {[propertyValue].flat().map((value, index) => {
                                                         
                                                         return (
-                                                            <p key={index} > {String(value)} </p>
+                                                            <p key={`${propertyKey}-${index}`} > {String(value)} </p>
                                                         );
                                                     })}
                                                 </Col>


### PR DESCRIPTION
Currently in the overview page (IDCard component) the fields that had no input from the users were still visible with a header and "undefined" as info. With this PR, these fields are no longer visible in the IDCard, as the header is not shown if the value is "undefined", therefore not filled with any info.

Changes:
- Removed the `arrayToNewline` helper function
- Removed the `idCardValue` css style, as it was only used to render one string to multiple new lines
-  Fields with `undefined` values are no longer shown
-  Single values are rendered as one` <p> `and arrays are rendered as multiple `<p>` elements

https://naturalis.atlassian.net/browse/DD-3110

<img width="398" height="919" alt="image" src="https://github.com/user-attachments/assets/63e5a1a6-910c-4d32-957f-961dbf476b67" />

<img width="398" height="919" alt="image" src="https://github.com/user-attachments/assets/e7597356-efb7-42df-99f1-172a2a06c1e1" />