### PR TITLE
Updated IDCard fields, schema and type for MAS

### DIFF
--- a/src/app/types/MachineAnnotationService.d.ts
+++ b/src/app/types/MachineAnnotationService.d.ts
@@ -112,9 +112,9 @@ export interface MachineAnnotationService {
    */
   "ods:slaDocumentation"?: string;
   /**
-   * Kafka topic through which the MAS receives messages. Defaults to PID of the Machine Annotation Service
+   * RabbitMQ queue name through which the MAS receives messages. Value is the suffix of the Machine Annotation Service PID
    */
-  "ods:topicName"?: string;
+  "ods:topicName": string;
   /**
    * The maximum amount of this MAS that can simultaneously run without causing issues
    */
@@ -136,6 +136,10 @@ export interface MachineAnnotationService {
    * Secret variables to supply to the Machine Annotation Service, sensitive
    */
   "ods:hasSecretVariables"?: SecretVariable[];
+  /**
+   * Indicates if the MAS may be run on specimen and/or media as they are ingested into DiSSCo. Should be able to support the appropriate amount of traffic.
+   */
+  "ods:isIngestionCompatible"?: boolean;
 }
 /**
  * Contains information about the creator of this MachineAnnotationService Digital Object, the agent creating this record in DiSSCo's system
@@ -149,11 +153,11 @@ export interface Agent {
    * The type of the agent, the prov ontology is only used in the prov-o ods:CreateUpdateTombstoneEvent
    */
   "@type":
-    | "schema:Person"
-    | "schema:Organization"
-    | "schema:SoftwareApplication"
-    | "prov:Person"
-    | "prov:SoftwareAgent";
+  | "schema:Person"
+  | "schema:Organization"
+  | "schema:SoftwareApplication"
+  | "prov:Person"
+  | "prov:SoftwareAgent";
   /**
    * The primary unique identifier of the Agent object. All identifiers will also be added to the ods:hasIdentifiers array
    */
@@ -254,28 +258,28 @@ export interface Identifier {
    * The type of the value in the `dcterms:identifier` field
    */
   "dcterms:type"?:
-    | "ARK"
-    | "arXiv"
-    | "bibcode"
-    | "DOI"
-    | "EAN13"
-    | "EISSN"
-    | "Handle"
-    | "IGSN"
-    | "ISBN"
-    | "ISSN"
-    | "ISTC"
-    | "LISSN"
-    | "LSID"
-    | "PMID"
-    | "PURL"
-    | "UPC"
-    | "URL"
-    | "URN"
-    | "w3id"
-    | "UUID"
-    | "Other"
-    | "Locally unique identifier";
+  | "ARK"
+  | "arXiv"
+  | "bibcode"
+  | "DOI"
+  | "EAN13"
+  | "EISSN"
+  | "Handle"
+  | "IGSN"
+  | "ISBN"
+  | "ISSN"
+  | "ISTC"
+  | "LISSN"
+  | "LSID"
+  | "PMID"
+  | "PURL"
+  | "UPC"
+  | "URL"
+  | "URN"
+  | "w3id"
+  | "UUID"
+  | "Other"
+  | "Locally unique identifier";
   /**
    * The value for the identifier
    */
@@ -296,11 +300,11 @@ export interface Identifier {
    * Indicates whether the identifier is a persistent identifier
    */
   "ods:gupriLevel"?:
-    | "LocallyUniqueStable"
-    | "GloballyUniqueStable"
-    | "GloballyUniqueStableResolvable"
-    | "GloballyUniqueStablePersistentResolvable"
-    | "GloballyUniqueStablePersistentResolvableFDOCompliant";
+  | "LocallyUniqueStable"
+  | "GloballyUniqueStable"
+  | "GloballyUniqueStableResolvable"
+  | "GloballyUniqueStablePersistentResolvable"
+  | "GloballyUniqueStablePersistentResolvableFDOCompliant";
   /**
    * Indicates the status of the identifier
    */
@@ -318,11 +322,11 @@ export interface Agent1 {
    * The type of the agent, the prov ontology is only used in the prov-o ods:CreateUpdateTombstoneEvent
    */
   "@type":
-    | "schema:Person"
-    | "schema:Organization"
-    | "schema:SoftwareApplication"
-    | "prov:Person"
-    | "prov:SoftwareAgent";
+  | "schema:Person"
+  | "schema:Organization"
+  | "schema:SoftwareApplication"
+  | "prov:Person"
+  | "prov:SoftwareAgent";
   /**
    * The primary unique identifier of the Agent object. All identifiers will also be added to the ods:hasIdentifiers array
    */
@@ -456,11 +460,11 @@ export interface Agent2 {
    * The type of the agent, the prov ontology is only used in the prov-o ods:CreateUpdateTombstoneEvent
    */
   "@type":
-    | "schema:Person"
-    | "schema:Organization"
-    | "schema:SoftwareApplication"
-    | "prov:Person"
-    | "prov:SoftwareAgent";
+  | "schema:Person"
+  | "schema:Organization"
+  | "schema:SoftwareApplication"
+  | "prov:Person"
+  | "prov:SoftwareAgent";
   /**
    * The primary unique identifier of the Agent object. All identifiers will also be added to the ods:hasIdentifiers array
    */

--- a/src/components/mas/Mas.tsx
+++ b/src/components/mas/Mas.tsx
@@ -112,16 +112,23 @@ const Mas = () => {
                             <Col lg={{ span: 4 }}>
                                 <IDCard identifier={(mas['@id'] ?? mas['schema:identifier']).replace(RetrieveEnvVariable('HANDLE_URL'), '')}
                                     IDCardProperties={{
-                                        name: mas['schema:name'],
-                                        containerImage: mas['ods:containerImage'],
-                                        containerTag: mas['ods:containerTag'],
-                                        sourceCodeRepository: mas['schema:codeRepository'],
-                                        codeMaintainer: mas['schema:maintainer']?.['schema:identifier'],
-                                        codeLicense: mas['schema:license'],
-                                        supportContact: mas['schema:ContactPoint']?.['schema:url'],
-                                        slaDocumentation: mas['ods:slaDocumentation'],
-                                        maxReplicas: mas['ods:maxReplicas'],
-                                        batchingPermitted: mas['ods:batchingPermitted'] ? 'True' : 'False'
+                                        'Name': mas['schema:name'],
+                                        'Container Image': mas['ods:containerImage'],
+                                        'Container Tag': mas['ods:containerTag'],
+                                        'Source Code Repository': mas['schema:codeRepository'],
+                                        'Service Availability': mas['ods:serviceAvailability'],
+                                        'Code Maintainer': mas['schema:maintainer']?.['schema:identifier'],
+                                        'Code License': mas['schema:license'],
+                                        'Contact Point': mas['schema:ContactPoint']?.['schema:url'],
+                                        'SLA Documentation': mas['ods:slaDocumentation'],
+                                        'Max Replicas': mas['ods:maxReplicas'],
+                                        'Creative Work Status': mas['schema:creativeWorkStatus'],
+                                        'Programming Language': mas['schema:programmingLanguage'],
+                                        'Time to Live': mas['ods:timeToLive'],
+                                        'Environmental Variables': mas['ods:hasEnvironmentalVariables'],
+                                        'Secret Variables': mas['ods:hasSecretVariables'],
+                                        'Ingestion Compatible': mas['ods:isIngestionCompatible'],
+                                        'Batching Permitted': mas['ods:batchingPermitted'] ? 'True' : 'False'
                                     }}
                                 />
                             </Col>

--- a/src/sources/dataModel/machineAnnotationService.json
+++ b/src/sources/dataModel/machineAnnotationService.json
@@ -1,1 +1,274 @@
-{"$id":"https://schemas.dissco.tech/schemas/fdo-type/machine-annotation-service/0.4.0/machine-annotation-service.json","$schema":"https://json-schema.org/draft/2020-12/schema","$comment":"Machine Annotation Service Version 0.4.0","title":"MachineAnnotationService","type":"object","description":"Automated annotation services that enhance biodiversity data","properties":{"@id":{"type":"string","description":"The unique identifier (handle) of the Machine Annotation Service object","pattern":"^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}","examples":["https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX","https://hdl.handle.net/20.5000.1025/JH1-C37-E7F"]},"@type":{"type":"string","description":"The type of the object, in this case ods:MachineAnnotationService","const":"ods:MachineAnnotationService"},"schema:identifier":{"type":"string","description":"Handle of the Machine Annotation Service","pattern":"^https://hdl\\.handle\\.net/[\\w.]+/(.){3}-(.){3}-(.){3}","examples":["https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX","https://hdl.handle.net/20.5000.1025/JH1-C37-E7F"]},"ods:fdoType":{"type":"string","description":"The DOI to the FDO type of the object","pattern":"^https://doi\\.org/[\\w\\.]+/[\\w\\.]+","examples":["https://doi.org/21.T11148/417a4f472f60f7974c12"]},"ods:status":{"type":"string","enum":["Draft","Active","Tombstone"],"description":"The status of the Digital Object. A digital object can be in Draft, when it is not published yet. Active when it is published and the object is active and Tombstone which means the object has been archived."},"schema:version":{"type":"integer","minimum":1,"description":"The version of the object, each change generates a new version. The version starts at 1 and each change will increment the version number with 1"},"schema:name":{"type":"string","description":"Name of the Machine Annotation Service as provided by the user, https://schema.org/name","examples":["GBIF Linker Service"]},"schema:description":{"type":"string","description":"Description of the Machine Annotation Service as provided by the user, https://schema.org/description","examples":["A service that links GBIF records to a DiSSCo Digital Specimen. It creates an EntityRelationship indicating the relationship"]},"schema:dateCreated":{"type":"string","description":"Timestamp of creation. Internally generated, following the ISO Date Time Format yyyy-MM-dd'T'HH:mm:ss.SSSXXX","format":"date-time","examples":["2021-06-01T12:00:000Z"]},"schema:dateModified":{"type":"string","description":"Timestamp of last modification. Internally generated, following the ISO Date Time Format yyyy-MM-dd'T'HH:mm:ss.SSSXXX","format":"date-time","examples":["2021-06-06T13:22:00.445Z"]},"schema:creator":{"type":"object","description":"Contains information about the creator of this MachineAnnotationService Digital Object, the agent creating this record in DiSSCo's system","$ref":"/home/tom/Documents/GitHub/orchestration-frontend/src/sources/dataModel/agent.json"},"ods:containerImage":{"type":"string","description":"The URI to the location of the image in a public container repository. Should only contain the image name and not the tag","examples":["public.ecr.aws/dissco/mindat-georeferencing"]},"ods:containerTag":{"type":"string","description":"The image tag of the container image. This should not be `latest` but point to a specific version. On an update of the application a new image tag should be generated and the Digital Object should be updated","examples":["sha-cb76994"]},"ods:hasTargetDigitalObjectFilter":{"type":"object","description":"Filters describing the criteria that a Digital Object must meet in order to apply the MAS. No filters implies the MAS may run on *any* digital object. Field names are given in JSON paths, and accepted values for that field are provided as an arrays. An `*` can be used as a wildcard, indicating any value is seen as valid","examples":[{"$['ods:type']":["https://doi.org/21.T11148/894b1e6cad57e921764e"],"$['ods:topicDiscipline']":["Astrogeology","Geology","Palaeontology","Other Geodiversity","Unclassified"],"$['ods:hasEvents'][*]['ods:hasLocation']['dwc:locality']":["*"]}]},"schema:creativeWorkStatus":{"type":"string","description":"The current status of the service in terms of its service lifecycle","examples":["Alpha","Production"]},"schema:codeRepository":{"type":"string","format":"url","description":"Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex)","examples":["https://github.com/rtdeb/GeoPick","https://github.com/DiSSCo/dissco-core-backend"]},"schema:programmingLanguage":{"type":"string","description":"The primary programming language used by the MAS","examples":["Python","Java 17"]},"ods:serviceAvailability":{"type":"string","description":"Availability commitment in uptime percentage of the service provider as described in the SLA","examples":["99.9%","95.0%"]},"schema:maintainer":{"type":"object","description":"Party maintaining the code, could be an schema:Organisation or a schema:Person","$ref":"/home/tom/Documents/GitHub/orchestration-frontend/src/sources/dataModel/agent.json"},"schema:license":{"type":"string","format":"url","description":"A license document which applies to this Machine Annotation Service","examples":["https://opensource.org/license/Apache-2.0","https://opensource.org/license/mit"]},"schema:ContactPoint":{"type":"object","description":"The contact point for support and information for the Machine Annotation Service","properties":{"schema:description":{"type":"string","description":"General description of the contact point"},"schema:email":{"type":"string","format":"email","description":"Email of the contact point"},"schema:url":{"type":"string","format":"url","description":"URL of the contact point, this could be a link to a contact form or a link to a github issues page"},"schema:telephone":{"type":"string","description":"Telephone number of the contact point"}}},"ods:slaDocumentation":{"type":"string","format":"url","description":"Link to SLA documentation of the Machine Annotation Service","examples":["https://www.dissco.tech/sla/mas"]},"ods:topicName":{"type":"string","description":"Kafka topic through which the MAS receives messages. Defaults to PID of the Machine Annotation Service","examples":["p3r-7ff-s4n","fsj-g4m-l47"]},"ods:maxReplicas":{"type":"integer","description":"The maximum amount of this MAS that can simultaneously run without causing issues","minimum":1,"examples":[3]},"ods:batchingPermitted":{"type":"boolean","description":"Whether or not this Machine Annotation Service can create Batch Annotations. Machine Annotations Service outputs must then comply with batchMetadata, see https://schemas.dissco.tech/schemas/annotations/0.1.0/annotation-event.json"},"ods:timeToLive":{"type":"integer","minimum":3600,"description":"Time in milliseconds the MAS message may remain in the Kafka Queue before being marked as timed out. Min 1 hour.","examples":[86400000,43200000]},"ods:hasTombstoneMetadata":{"type":"object","description":"Object containing the tombstone metadata of the object","$ref":"/home/tom/Documents/GitHub/orchestration-frontend/src/sources/dataModel/tombstoneMetadata.json"},"ods:hasEnvironmentalVariables":{"type":"array","description":"Environmental variables to supply to the Machine Annotation Service, non-sensitive","items":{"$ref":"/home/tom/Documents/GitHub/orchestration-frontend/src/sources/dataModel/environmentalVariable.json"}},"ods:hasSecretVariables":{"type":"array","description":"Secret variables to supply to the Machine Annotation Service, sensitive","items":{"$ref":"/home/tom/Documents/GitHub/orchestration-frontend/src/sources/dataModel/secretVariable.json"}}},"required":["@type","schema:identifier","ods:fdoType","schema:name","schema:dateCreated","schema:creator","schema:dateModified","ods:containerImage","ods:containerTag","ods:batchingPermitted","ods:timeToLive"],"additionalProperties":false}
+{
+    "$id": "https://schemas.dissco.tech/schemas/fdo-type/machine-annotation-service/0.4.0/machine-annotation-service.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$comment": "Machine Annotation Service Version 0.4.0",
+    "title": "MachineAnnotationService",
+    "type": "object",
+    "description": "Automated annotation services that enhance biodiversity data",
+    "properties": {
+        "@id": {
+            "type": "string",
+            "description": "The unique identifier (handle) of the Machine Annotation Service object",
+            "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
+            "examples": [
+                "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX",
+                "https://hdl.handle.net/20.5000.1025/JH1-C37-E7F"
+            ]
+        },
+        "@type": {
+            "type": "string",
+            "description": "The type of the object, in this case ods:MachineAnnotationService",
+            "const": "ods:MachineAnnotationService"
+        },
+        "schema:identifier": {
+            "type": "string",
+            "description": "Handle of the Machine Annotation Service",
+            "pattern": "^https:\/\/hdl\\.handle\\.net\/[\\w.]+\/(.){3}-(.){3}-(.){3}",
+            "examples": [
+                "https://hdl.handle.net/20.5000.1025/XXX-XXX-XXX",
+                "https://hdl.handle.net/20.5000.1025/JH1-C37-E7F"
+            ]
+        },
+        "ods:fdoType": {
+            "type": "string",
+            "description": "The DOI to the FDO type of the object",
+            "pattern": "^https:\/\/doi\\.org\/[\\w\\.]+/[\\w\\.]+",
+            "examples": [
+                "https://doi.org/21.T11148/417a4f472f60f7974c12"
+            ]
+        },
+        "ods:status": {
+            "type": "string",
+            "enum": [
+                "Draft",
+                "Active",
+                "Tombstone"
+            ],
+            "description": "The status of the Digital Object. A digital object can be in Draft, when it is not published yet. Active when it is published and the object is active and Tombstone which means the object has been archived."
+        },
+        "schema:version": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "The version of the object, each change generates a new version. The version starts at 1 and each change will increment the version number with 1"
+        },
+        "schema:name": {
+            "type": "string",
+            "description": "Name of the Machine Annotation Service as provided by the user, https://schema.org/name",
+            "examples": [
+                "GBIF Linker Service"
+            ]
+        },
+        "schema:description": {
+            "type": "string",
+            "description": "Description of the Machine Annotation Service as provided by the user, https://schema.org/description",
+            "examples": [
+                "A service that links GBIF records to a DiSSCo Digital Specimen. It creates an EntityRelationship indicating the relationship"
+            ]
+        },
+        "schema:dateCreated": {
+            "type": "string",
+            "description": "Timestamp of creation. Internally generated, following the ISO Date Time Format yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+            "format": "date-time",
+            "examples": [
+                "2021-06-01T12:00:000Z"
+            ]
+        },
+        "schema:dateModified": {
+            "type": "string",
+            "description": "Timestamp of last modification. Internally generated, following the ISO Date Time Format yyyy-MM-dd'T'HH:mm:ss.SSSXXX",
+            "format": "date-time",
+            "examples": [
+                "2021-06-06T13:22:00.445Z"
+            ]
+        },
+        "schema:creator": {
+            "type": "object",
+            "description": "Contains information about the creator of this MachineAnnotationService Digital Object, the agent creating this record in DiSSCo's system",
+            "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/agent.json"
+        },
+        "ods:containerImage": {
+            "type": "string",
+            "description": "The URI to the location of the image in a public container repository. Should only contain the image name and not the tag",
+            "examples": [
+                "public.ecr.aws/dissco/mindat-georeferencing"
+            ]
+        },
+        "ods:containerTag": {
+            "type": "string",
+            "description": "The image tag of the container image. This should not be `latest` but point to a specific version. On an update of the application a new image tag should be generated and the Digital Object should be updated",
+            "examples": [
+                "sha-cb76994"
+            ]
+        },
+        "ods:hasTargetDigitalObjectFilter": {
+            "type": "object",
+            "description": "Filters describing the criteria that a Digital Object must meet in order to apply the MAS. No filters implies the MAS may run on *any* digital object. Field names are given in JSON paths, and accepted values for that field are provided as an arrays. An `*` can be used as a wildcard, indicating any value is seen as valid",
+            "examples": [
+                {
+                    "$['ods:type']": [
+                        "https://doi.org/21.T11148/894b1e6cad57e921764e"
+                    ],
+                    "$['ods:topicDiscipline']": [
+                        "Astrogeology",
+                        "Geology",
+                        "Palaeontology",
+                        "Other Geodiversity",
+                        "Unclassified"
+                    ],
+                    "$['ods:hasEvents'][*]['ods:hasLocation']['dwc:locality']": [
+                        "*"
+                    ]
+                }
+            ]
+        },
+        "schema:creativeWorkStatus": {
+            "type": "string",
+            "description": "The current status of the service in terms of its service lifecycle",
+            "examples": [
+                "Alpha",
+                "Production"
+            ]
+        },
+        "schema:codeRepository": {
+            "type": "string",
+            "format": "url",
+            "description": "Link to the repository where the un-compiled, human readable code and related code is located (SVN, GitHub, CodePlex)",
+            "examples": [
+                "https://github.com/rtdeb/GeoPick",
+                "https://github.com/DiSSCo/dissco-core-backend"
+            ]
+        },
+        "schema:programmingLanguage": {
+            "type": "string",
+            "description": "The primary programming language used by the MAS",
+            "examples": [
+                "Python",
+                "Java 17"
+            ]
+        },
+        "ods:serviceAvailability": {
+            "type": "string",
+            "description": "Availability commitment in uptime percentage of the service provider as described in the SLA",
+            "examples": [
+                "99.9%",
+                "95.0%"
+            ]
+        },
+        "schema:maintainer": {
+            "type": "object",
+            "description": "Party maintaining the code, could be an schema:Organisation or a schema:Person",
+            "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/agent.json"
+        },
+        "schema:license": {
+            "type": "string",
+            "format": "url",
+            "description": "A license document which applies to this Machine Annotation Service",
+            "examples": [
+                "https://opensource.org/license/Apache-2.0",
+                "https://opensource.org/license/mit"
+            ]
+        },
+        "schema:ContactPoint": {
+            "type": "object",
+            "description": "The contact point for support and information for the Machine Annotation Service",
+            "properties": {
+                "schema:description": {
+                    "type": "string",
+                    "description": "General description of the contact point"
+                },
+                "schema:email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Email of the contact point"
+                },
+                "schema:url": {
+                    "type": "string",
+                    "format": "url",
+                    "description": "URL of the contact point, this could be a link to a contact form or a link to a github issues page"
+                },
+                "schema:telephone": {
+                    "type": "string",
+                    "description": "Telephone number of the contact point"
+                }
+            }
+        },
+        "ods:slaDocumentation": {
+            "type": "string",
+            "format": "url",
+            "description": "Link to SLA documentation of the Machine Annotation Service",
+            "examples": [
+                "https://www.dissco.tech/sla/mas"
+            ]
+        },
+        "ods:topicName": {
+            "type": "string",
+            "description": "RabbitMQ queue name through which the MAS receives messages. Value is the suffix of the Machine Annotation Service PID",
+            "examples": [
+                "p3r-7ff-s4n",
+                "fsj-g4m-l47"
+            ]
+        },
+        "ods:maxReplicas": {
+            "type": "integer",
+            "description": "The maximum amount of this MAS that can simultaneously run without causing issues",
+            "minimum": 1,
+            "examples": [
+                3
+            ]
+        },
+        "ods:batchingPermitted": {
+            "type": "boolean",
+            "description": "Whether or not this Machine Annotation Service can create Batch Annotations. Machine Annotations Service outputs must then comply with batchMetadata, see https://schemas.dissco.tech/schemas/annotations/0.1.0/annotation-event.json"
+        },
+        "ods:timeToLive": {
+            "type": "integer",
+            "minimum": 3600,
+            "description": "Time in milliseconds the MAS message may remain in the Kafka Queue before being marked as timed out. Min 1 hour.",
+            "examples": [
+                86400000,
+                43200000
+            ]
+        },
+        "ods:hasTombstoneMetadata": {
+            "type": "object",
+            "description": "Object containing the tombstone metadata of the object",
+            "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/tombstone-metadata.json"
+        },
+        "ods:hasEnvironmentalVariables": {
+            "type": "array",
+            "description": "Environmental variables to supply to the Machine Annotation Service, non-sensitive",
+            "items": {
+                "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/environmental-variable.json"
+            }
+        },
+        "ods:hasSecretVariables": {
+            "type": "array",
+            "description": "Secret variables to supply to the Machine Annotation Service, sensitive",
+            "items": {
+                "$ref": "https://schemas.dissco.tech/schemas/fdo-type/shared-model/0.4.0/secret-variable.json"
+            }
+        },
+        "ods:isIngestionCompatible": {
+            "type": "boolean",
+            "description": "Indicates if the MAS may be run on specimen and/or media as they are ingested into DiSSCo. Should be able to support the appropriate amount of traffic.",
+            "examples": [
+                true
+            ]
+        }
+    },
+    "required": [
+        "@type",
+        "schema:identifier",
+        "ods:fdoType",
+        "schema:name",
+        "ods:topicName",
+        "schema:dateCreated",
+        "schema:creator",
+        "schema:dateModified",
+        "ods:containerImage",
+        "ods:containerTag",
+        "ods:batchingPermitted",
+        "ods:timeToLive"
+    ],
+    "additionalProperties": false
+}


### PR DESCRIPTION
Currently, the MAS overview page only shows a few basic fields (name, description, endpoint, creation date). Optional fields are not displayed, even when they are filled in by the user.

Currently, when the user clicks on a MAS, the overview page includes only:
- name
- containerImage
- containerTag
- sourceCodeRepository
- codeMaintainer
- codeLicense
- supportContact
- slaDocumentation
- maxReplicas
- batchingPermitted
- description
- Target Digital Object Filters description

This PR adds the following optional fields to the overview page:
- Service Availability
- Creative Work Status
- Programming Language
- Time to live
- Environmental variables
- Secret Variables
- Is ingestion compatible

These fields are already supported by the backend, but they were not available in the frontend because they were missing from the schema and the generated TypeScript types. Since the "MAS" type is generated from the JSON schema, the schema needed to be updated first so the new fields could be used in the code.

In detail the following changes are made:
- Updated the MachineAnnotationService JSON schema (based on the [latest version](https://schemas.dissco.tech/schemas/fdo-type/machine-annotation-service/0.3.0/machine-annotation-service.json)) to include the missing fields
- Regenerated the TypeScript type for the "MAS" from the updated schema (MachineAnnotationService.d.ts)
- Added the new fields to the MAS overview page