### PR TITLE
Removed not required fields form validaiton logic for MAS

### DIFF
--- a/src/components/formBuilder/FormBuilder.tsx
+++ b/src/components/formBuilder/FormBuilder.tsx
@@ -90,12 +90,12 @@ const FormBuilder = () => {
             const route = location.pathname.split('/', 2)[1];
             const id = `${location.pathname.split('/', 3)[2]}/${location.pathname.split('/', 4)[3]}`;
 
-                /* Set edit target */
-                DefineEditTarget(route, id).then((editTarget) => {
-                    dispatch(setEditTarget(editTarget));
-                }).catch(error => {
-                    console.warn(error);
-                });
+            /* Set edit target */
+            DefineEditTarget(route, id).then((editTarget) => {
+                dispatch(setEditTarget(editTarget));
+            }).catch(error => {
+                console.warn(error);
+            });
         } else {
             dispatch(setEditTarget(undefined));
         }
@@ -266,9 +266,7 @@ const FormBuilder = () => {
                         const requiredFieldsMAS = [
                             'masName',
                             'masContainerImage',
-                            'masContainerTag',
-                            'ods:hasTargetDigitalObjectFilter',
-                            'masBatchingPermitted'
+                            'masContainerTag'
                         ];
 
                         if (location.pathname.includes('source-system') && formPage === 0) {

--- a/src/components/formBuilder/formFields/MasFiltersField.tsx
+++ b/src/components/formBuilder/formFields/MasFiltersField.tsx
@@ -69,13 +69,6 @@ const MasFiltersField = (props: Props) => {
                     <Col className="col-lg-auto">
                         <Field name="targetDigitalObjectFiltersOptions"
                             as="select"
-                            validate={() => {
-                                const addedFilters = formValues?.['ods:hasTargetDigitalObjectFilter'];
-
-                                if (Object.keys(addedFilters).length === 0) {
-                                    return 'Required';
-                                }
-                            }}
                         >
                             <option value="" disabled={true}> Select a harmonised attribute </option>
 

--- a/src/components/mas/components/MasForm.tsx
+++ b/src/components/mas/components/MasForm.tsx
@@ -14,9 +14,7 @@ const MasForm = (DetermineFormField: Function, mas?: MachineAnnotationService) =
     const requiredFields = new Set([
         'schema:name',
         'ods:containerImage',
-        'ods:containerTag',
-        'ods:hasTargetDigitalObjectFilter',
-        'ods:batchingPermitted'
+        'ods:containerTag'
     ]);
 
     /* Generate MAS form fields */


### PR DESCRIPTION
Currently, some fields in the MAS form that are marked as required in the form don’t need to be and the validation needs to be updated. These fields are:
- Batching permitted
- Target Digital Object Filter

Changes:
-  Removed the fields from the form validation logic 
-  The visual required asterisk is removed form these two fields
-  Removed validation logic from `MasFiltersField.tsx `because it was forcing the user to select at least one filter before the form could be submitted

https://naturalis.atlassian.net/browse/DD-3109

<img width="659" height="958" alt="image" src="https://github.com/user-attachments/assets/6076dbbe-e8e7-4dc4-9a71-a6d8fc25a73a" />